### PR TITLE
[PoseEditor] Add wildcard support to search and improve search performance

### DIFF
--- a/Core.PoseEditor/AMModules/BonesEditor.cs
+++ b/Core.PoseEditor/AMModules/BonesEditor.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Xml;
 using ToolBox.Extensions;
 using UnityEngine;
@@ -1234,6 +1235,11 @@ namespace HSPE.AMModules
                 }
             }
         }
+        private static bool WildCardSearch(string text, string search)
+        {
+            string regex = "^.*" + Regex.Escape(search).Replace("\\?", ".").Replace("\\*", ".*") + ".*$";
+            return Regex.IsMatch(text, regex, RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        }
 
         private void DisplayObjectTree(GameObject go, int indent)
         {
@@ -1247,7 +1253,7 @@ namespace HSPE.AMModules
                 aliased = false;
             }
 
-            if (_search.Length == 0 || go.name.IndexOf(_search, StringComparison.OrdinalIgnoreCase) != -1 || (aliased && displayedName.IndexOf(_search, StringComparison.OrdinalIgnoreCase) != -1))
+            if (_search.Length == 0 || WildCardSearch(go.name, _search) || (aliased && WildCardSearch(displayedName, _search)))
             {
                 Color c = GUI.color;
                 if (_dirtyBones.ContainsKey(go))

--- a/Core.PoseEditor/AMModules/BonesEditor.cs
+++ b/Core.PoseEditor/AMModules/BonesEditor.cs
@@ -290,7 +290,7 @@ namespace HSPE.AMModules
             GUILayout.EndHorizontal();
             _boneEditionScroll = GUILayout.BeginScrollView(_boneEditionScroll, GUI.skin.box, GUILayout.ExpandHeight(true));
 
-            if (_search != oldSearch || _search == null)
+            if (_search != oldSearch)
                 UpdateSearch();
 
             foreach (Transform child in _parent.transform)

--- a/Core.PoseEditor/AMModules/BonesEditor.cs
+++ b/Core.PoseEditor/AMModules/BonesEditor.cs
@@ -1240,10 +1240,10 @@ namespace HSPE.AMModules
                 }
             }
         }
-        private static bool WildCardSearch(string text, string search)
+        private bool WildCardSearch(string text, string search)
         {
             string regex = "^.*" + Regex.Escape(search).Replace("\\?", ".").Replace("\\*", ".*") + ".*$";
-            return Regex.IsMatch(text, regex, RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            return Regex.IsMatch(text, regex, RegexOptions.IgnoreCase);
         }
 
         private void UpdateSearch()

--- a/Core.PoseEditor/AMModules/BonesEditor.cs
+++ b/Core.PoseEditor/AMModules/BonesEditor.cs
@@ -290,13 +290,12 @@ namespace HSPE.AMModules
             GUILayout.EndHorizontal();
             _boneEditionScroll = GUILayout.BeginScrollView(_boneEditionScroll, GUI.skin.box, GUILayout.ExpandHeight(true));
 
-            if (_search != oldSearch)
+            if (_search != oldSearch && _search.Length > 0)
                 UpdateSearch();
 
             foreach (Transform child in _parent.transform)
-            {
                 DisplayObjectTree(child.gameObject, 0);
-            }
+
             GUILayout.EndScrollView();
             GUILayout.BeginHorizontal();
             GUILayout.Label("Alias", GUILayout.ExpandWidth(false));
@@ -1276,10 +1275,11 @@ namespace HSPE.AMModules
 
         private void DisplayObjectTree(GameObject go, int indent)
         {
-            if (_boneAliases.TryGetValue(go.name, out string displayedName) == false)
+        if (_boneAliases.TryGetValue(go.name, out string displayedName) == false)
                 displayedName = go.name;
 
-            if (searchResults.Contains(go))
+
+            if (_search.Length == 0 || searchResults.Contains(go))
             {
                 Color c = GUI.color;
                 if (_dirtyBones.ContainsKey(go))


### PR DESCRIPTION
wildcard support: translate "\*" and "?" to regex (".\*" and ".") in the background for search.

The search happened every frame at first, which could cause slowdowns (and was only made worse by the added regex). Now the search itself is only performed when the filter is updated