### PR TITLE
[PE][KKS] Fix same key exception

### DIFF
--- a/Core.PoseEditor/AMModules/BlendShapesEditor.cs
+++ b/Core.PoseEditor/AMModules/BlendShapesEditor.cs
@@ -974,15 +974,17 @@ namespace HSPE.AMModules
 
         private void Init()
         {
+            _instanceByFaceBlendShape.RemoveIfNullKey();
+
             _headRenderer = null;
 #if HONEYSELECT
-            _instanceByFaceBlendShape.Add(this._target.ociChar.charBody.fbsCtrl, this);
+            _instanceByFaceBlendShape[this._target.ociChar.charBody.fbsCtrl] = this;
 #elif PLAYHOME
-            _instanceByFaceBlendShape.Add(this._target.ociChar.charInfo.human, this);
+            _instanceByFaceBlendShape[this._target.ociChar.charInfo.human] = this;
 #elif KOIKATSU
-            _instanceByFaceBlendShape.Add(_target.ociChar.charInfo.fbsCtrl, this);
+            _instanceByFaceBlendShape[_target.ociChar.charInfo.fbsCtrl] = this;
 #elif AISHOUJO || HONEYSELECT2
-            _instanceByFaceBlendShape.Add(_target.ociChar.charInfo.fbsCtrl, this);
+            _instanceByFaceBlendShape[_target.ociChar.charInfo.fbsCtrl] = this;
 #endif
 
             List<SkinnedMeshRenderer> skinnedMeshRendererList = new List<SkinnedMeshRenderer>();

--- a/Core.PoseEditor/Extensions.cs
+++ b/Core.PoseEditor/Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using Vectrosity;
+using System.Collections.Generic;
 
 namespace HSPE
 {
@@ -15,6 +16,18 @@ namespace HSPE
         {
             for (int i = 0; i < self.points3.Count; i++)
                 self.points2[i] = points[i];
+        }
+
+        public static void RemoveIfNullKey<Key, Value>(this Dictionary<Key, Value> dict) where Key : UnityEngine.Object
+        {
+            List<Key> removeKeys = new List<Key>();
+
+            foreach (var key in dict.Keys)
+                if ((UnityEngine.Object)key == null)
+                    removeKeys.Add(key);
+
+            foreach (var removeKey in removeKeys)
+                dict.Remove(removeKey);
         }
     }
 }


### PR DESCRIPTION
Fixed a bug in Sunshine Studio that caused a Same key exception in BlendShapesEditor.Init when changing characters.

Reproduction procedure:
1. launch KKS studio
2. load any character
3. change character

```
ArgumentException: An item with the same key has already been added. Key: ct_head (FaceBlendShape)
  at System.Collections.Generic.Dictionary`2[TKey,TValue].TryInsert (TKey key, TValue value, System.Collections.Generic.InsertionBehavior behavior) [0x000c1] in <fb001e01371b4adca20013e0ac763896>:0 
  at System.Collections.Generic.Dictionary`2[TKey,TValue].Add (TKey key, TValue value) [0x00000] in <fb001e01371b4adca20013e0ac763896>:0 
  at HSPE.AMModules.BlendShapesEditor.Init () [0x00022] in <4777fff9a68141d0817e44d0eec04cdb>:0 
  at HSPE.AMModules.BlendShapesEditor.<OnCharacterReplaced>b__49_0 () [0x00008] in <4777fff9a68141d0817e44d0eec04cdb>:0 
  at ToolBox.Extensions.MonoBehaviourExtensions+<ExecuteDelayed_Routine>d__2.MoveNext () [0x00062] in <4777fff9a68141d0817e44d0eec04cdb>:0 
  at UnityEngine.SetupCoroutine.InvokeMoveNext (System.Collections.IEnumerator enumerator, System.IntPtr returnValueAddress) [0x00026] in <548b4fa0e7e04f27a1b7580930bfb7dc>:0 
```
[output_log.txt](https://github.com/IllusionMods/HSPlugins/files/13522484/output_log.txt)

This bug did not occur on KK.
In KKS, the same ociChar.charInfo.fbsCtrl seems to be used even after the character is changed.
There is no guarantee of anything in the use of ociChar.charInfo.fbsCtrl, so I modified it to overwrite instead of Add.
