### PR TITLE
[PE] Fixed a bug that caused blendshapes to be reset when duplicating a character

### DIFF
--- a/Core.PoseEditor/AMModules/BlendShapesEditor.cs
+++ b/Core.PoseEditor/AMModules/BlendShapesEditor.cs
@@ -90,6 +90,8 @@ namespace HSPE.AMModules
         {
             public float weight;
             public float originalWeight;
+
+            public BlendShapeData Clone() { return (BlendShapeData)MemberwiseClone(); }
         }
 
         private class BlendLinkData
@@ -696,14 +698,18 @@ namespace HSPE.AMModules
             {
                 foreach (var skinnedMeshRenderer in other._dirtySkinnedMeshRenderers)
                 {
-                    if (other._dirtySkinnedMeshRenderers.TryGetValue(skinnedMeshRenderer.Key, out var dictionary))
-                    {
-                        skinnedMeshRenderer.Value.Clear();
-                        foreach (var keyValuePair in dictionary)
-                        {
-                            skinnedMeshRenderer.Value.Add(keyValuePair.Key, keyValuePair.Value);
-                        }
-                    }
+                    string rendererName = skinnedMeshRenderer.Key;
+                    if (!_skinnedMeshRenderers.ContainsKey(rendererName))
+                        continue;
+
+                    Dictionary<string, BlendShapeData> selfBsd;
+                    if( !_dirtySkinnedMeshRenderers.TryGetValue(rendererName, out selfBsd) )
+                         selfBsd = _dirtySkinnedMeshRenderers[rendererName] = new Dictionary<string, BlendShapeData>();
+
+                    var otherBsd = skinnedMeshRenderer.Value;
+
+                    foreach (var kvp in otherBsd)
+                        selfBsd[kvp.Key] = kvp.Value.Clone();
                 }
 
                 _blendShapesScroll = other._blendShapesScroll;


### PR DESCRIPTION
Fixed a bug that caused blendshapes to be reset when duplicating a character

Reproduction procedure:
1. Launch Studio
2. Add any character
3. Edit the character's blendshape
4. Select a character from the workspace and press Ctrl+D to duplicate
5. The original character's blendshape will be reset

This is due to the fact that the original blendshape was Clear()ed in LoadFrom. However, even if you return at the beginning of LoadFrom(), the blendshape will still be copied. It seems that somewhere else the blendshape is being duplicated by some other code.
But I thought it was not intended that LoadFrom not do the copying, so I fixed it for good.

As a side note, Clone() was not needed. It appears that the instances are not shared. Editing blendshapes is independent. However, the code before the fix reads as if the instances are shared. I thought that was not recommended and added Clone().