### PR TITLE
[HSUS] Call UnloadUnusedAsset when memory usage is under pressure

### DIFF
--- a/UsefulStuff.Core/Features/AutomaticMemoryClean.cs
+++ b/UsefulStuff.Core/Features/AutomaticMemoryClean.cs
@@ -1,12 +1,16 @@
 ﻿using System;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace HSUS.Features
 {
     public class AutomaticMemoryClean : IFeature
     {
         private float _lastCleanup;
+        private float _lastCheckedForceCleanup;
+        private int _countForceCleanup;
 
         public void Awake()
         {
@@ -17,23 +21,81 @@ namespace HSUS.Features
         {
         }
 
+        private void CleanMemory()
+        {
+            _lastCleanup = Time.unscaledTime;
+            Resources.UnloadUnusedAssets();
+            GC.Collect();
+        }
+
         private void Update()
         {
-            if (HSUS.AutomaticMemoryClean.Value
 #if HONEYSELECT
-                && OptimizeNEO._isCleaningResources == false
+            if( OptimizeNEO._isCleaningResources )
+                return;
 #endif
-            )
+
+            if (HSUS.AutomaticMemoryClean.Value)
             {
                 if (Time.unscaledTime - _lastCleanup > HSUS.AutomaticMemoryCleanInterval.Value)
                 {
-                    Resources.UnloadUnusedAssets();
-                    GC.Collect();
-                    _lastCleanup = Time.unscaledTime;
+                    CleanMemory();
                     if (EventSystem.current.sendNavigationEvents)
                         EventSystem.current.sendNavigationEvents = false;
                 }
             }
+
+            if (Time.unscaledTime - _lastCheckedForceCleanup > HSUS.ForceMemoryCleanInterval.Value && _countForceCleanup <= 8 )
+            {
+                _lastCheckedForceCleanup = Time.unscaledTime;
+
+                if (GetSystemMemoryLoad() >= HSUS.ForceMemoryCleanPercent.Value)
+                {
+                    ++_countForceCleanup;   //If a forced memory clear occurs several times in a row, clear is aborted.
+                    CleanMemory();
+                }
+                else
+                {
+                    _countForceCleanup = 0;
+                }                    
+            }
         }
+
+        /// <summary>
+        /// Returns OS memory usage (0~100%)
+        /// </summary>
+        /// <returns>0-100</returns>
+        public static uint GetSystemMemoryLoad()
+        {
+            try
+            {
+                MEMORYSTATUSEX stat = new MEMORYSTATUSEX();
+                stat.dwLength = (uint)Marshal.SizeOf(typeof(MEMORYSTATUSEX));
+
+                if (GlobalMemoryStatusEx(ref stat))
+                    return stat.dwMemoryLoad;
+            }
+            catch{}
+            
+            return 0;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct MEMORYSTATUSEX
+        {
+            public uint dwLength;
+            public uint dwMemoryLoad;
+            public ulong ullTotalPhys;
+            public ulong ullAvailPhys;
+            public ulong ullTotalPageFile;
+            public ulong ullAvailPageFile;
+            public ulong ullTotalVirtual;
+            public ulong ullAvailVirtual;
+            public ulong ullAvailExtendedVirtual;
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool GlobalMemoryStatusEx(ref MEMORYSTATUSEX lpBuffer);
     }
 }

--- a/UsefulStuff.Core/HSUS.cs
+++ b/UsefulStuff.Core/HSUS.cs
@@ -138,6 +138,8 @@ namespace HSUS
         internal static ConfigEntry<bool> AlternativeCenterToObjects { get; private set; }
         internal static ConfigEntry<bool> AutomaticMemoryClean { get; private set; }
         internal static ConfigEntry<int> AutomaticMemoryCleanInterval { get; private set; }
+        internal static ConfigEntry<int> ForceMemoryCleanPercent { get; private set; }
+        internal static ConfigEntry<int> ForceMemoryCleanInterval { get; private set; }
         internal static ConfigEntry<KeyboardShortcut> CopyTransformHotkey { get; private set; }
         internal static ConfigEntry<KeyboardShortcut> PasteTransformHotkey { get; private set; }
         internal static ConfigEntry<KeyboardShortcut> PasteTransformPositionOnlyHotkey { get; private set; }
@@ -199,6 +201,8 @@ namespace HSUS
             AlternativeCenterToObjects = Config.Bind("Studio controls", "Alternative Center To Objects", true, "Change how pressing F centers the camera.");
             AutomaticMemoryClean = Config.Bind("Performance", "Automatic Memory Cleaning", false, "Periodically clean memory from unused objects in case the game doesn't do it for whatever reason. When cleanup is performed the game/studio may stutter/lag for a moment.");
             AutomaticMemoryCleanInterval = Config.Bind("Performance", "Automatic Memory Cleaning Interval", 300, "How often to clean memory.");
+            ForceMemoryCleanPercent = Config.Bind("Performance", "Memory usage to be forced cleaned (%)", 90, "Force memory cleaning when memory usage (%) exceeds this value.");
+            ForceMemoryCleanInterval = Config.Bind("Performance", "Automatic Force Memory Cleaning Interval (s)", 20, "How often to forced clean memory. [s]");
 
             CopyTransformHotkey = Config.Bind("Improved Transform Operations", "Copy Transform", new KeyboardShortcut(KeyCode.C, KeyCode.LeftControl));
             PasteTransformHotkey = Config.Bind("Improved Transform Operations", "Paste Transform", new KeyboardShortcut(KeyCode.V, KeyCode.LeftControl));


### PR DESCRIPTION
Call Resources.UnloadUnusedAssets() when PC memory usage exceeds 90%. 
Please merge if it is OK.
I kept changing the clothes and it would hang. This is a fix to prevent that.

I kept pressing one of the following buttons in KKS and it hung up
![スクリーンショット 2024-01-04 211440](https://github.com/IllusionMods/HSPlugins/assets/4230203/9af08043-191c-42e9-8f97-d58e5cdcef2e)

Just before hang-up:
![スクリーンショット 2024-01-04 122207](https://github.com/IllusionMods/HSPlugins/assets/4230203/2517ad92-8b09-4943-b43e-4cc1b86d7e50)


The following is an excuse to say that I'm not proposing changes without knowing what they are.

I know that these kinds of fixes do not result in better operation in all user environments.
I also know that enabling [Automatic Memory Cleaning] and setting [Automatic Memory Cleaning Interval] to a small value will give similar results.

However, many users will just restart the game if it hangs due to lack of memory. Many users don't look at the options & don't change them.
So I think it is a good thing to change the default behavior so that hang-ups are less likely to occur.

This fix could turn some of the hangs due to memory leaks into petit freezes without changing much of the other behavior in many users' environments. I believe this is more desirable.


