### PR TITLE
Fixed patches where GUID was not specified

### DIFF
--- a/Core.PoseEditor/HSPE.cs
+++ b/Core.PoseEditor/HSPE.cs
@@ -75,7 +75,7 @@ namespace HSPE
             ConfigCrotchCorrectionByDefault = Config.Bind("Config", "Crotch Correction By Default", false);
             ConfigAnklesCorrectionByDefault = Config.Bind("Config", "AnklesCorrection By Default", false);
 
-            Harmony.CreateAndPatchAll(Assembly.GetExecutingAssembly());
+            Harmony.CreateAndPatchAll(Assembly.GetExecutingAssembly(), GUID);
         }
 
 #if AISHOUJO || HONEYSELECT2

--- a/UsefulStuff.Core/HSUS.cs
+++ b/UsefulStuff.Core/HSUS.cs
@@ -276,7 +276,7 @@ namespace HSUS
             UIUtility.Init();
 
             _harmonyInstance = HarmonyExtensions.CreateInstance(GUID);
-            Harmony.CreateAndPatchAll(Assembly.GetExecutingAssembly());
+            _harmonyInstance.PatchAll(Assembly.GetExecutingAssembly());
 
             foreach (IFeature feature in _features)
             {


### PR DESCRIPTION
GUID was not set in the patch.
Fixed because other GUID referencing mechanisms may not work.
HarmonyBefore and HarmonyAfter are affected.