### PR TITLE
[PE] Fix Null Reference Exception and more

### DIFF
--- a/Core.PoseEditor/AMModules/BlendShapesEditor.cs
+++ b/Core.PoseEditor/AMModules/BlendShapesEditor.cs
@@ -1186,6 +1186,7 @@ namespace HSPE.AMModules
             _rendererNames.Clear();
             _skinnedMeshRenderers.Clear();
             _dirtySkinnedMeshRenderers.Clear();
+            _parent._childObjects.RemoveWhere(gobj => gobj == null);
 
             foreach (SkinnedMeshRenderer skin in skinnedMeshRenderers)
             {

--- a/Core.PoseEditor/AMModules/DynamicBonesEditor.cs
+++ b/Core.PoseEditor/AMModules/DynamicBonesEditor.cs
@@ -1509,6 +1509,7 @@ namespace HSPE.AMModules
         private void RefreshDynamicBoneList()
         {
             if (_parent == null) return;
+            _parent._childObjects.RemoveWhere(gobj => gobj == null);
 
             _isBusy = true;
             DynamicBone[] dynamicBones = _parent.GetComponentsInChildren<DynamicBone>(true);

--- a/Core.PoseEditor/AMModules/IKEditor.cs
+++ b/Core.PoseEditor/AMModules/IKEditor.cs
@@ -1404,6 +1404,7 @@ namespace HSPE.AMModules
 
         private void RefreshIKList()
         {
+            _parent._childObjects.RemoveWhere(gobj => gobj == null);
             IK[] iks = _parent.GetComponentsInChildren<IK>(true);
             List<IK> toDelete = null;
             foreach (KeyValuePair<IK, IKWrapper> pair in _iks)

--- a/Core.PoseEditor/PoseController.cs
+++ b/Core.PoseEditor/PoseController.cs
@@ -174,13 +174,14 @@ namespace HSPE
             _dynamicBonesEditor.LoadFrom(other._dynamicBonesEditor);
             _blendShapesEditor.LoadFrom(other._blendShapesEditor);
             _ikEditor.LoadFrom(other._ikEditor);
-            foreach (GameObject ignoredObject in other._childObjects)
+
+            //Register as a child when a parent exists
+            var otherParent = other.transform.parent?.GetComponentInParent<PoseController>();
+
+            if (otherParent != null && otherParent._childObjects.Contains(other.gameObject) )
             {
-                if (ignoredObject == null)
-                    continue;
-                Transform obj = transform.Find(ignoredObject.transform.GetPathFrom(other.transform));
-                if (obj != null && obj != transform)
-                    _childObjects.Add(obj.gameObject);
+                var parent = transform.parent?.GetComponentInParent<PoseController>();
+                parent?._childObjects.Add(gameObject);
             }
         }
 


### PR DESCRIPTION
Fixed #58 and related code.
Please merge if it looks OK.

Added workaround for cases with deleted objects in _childObjects.

Code for copying _childObjects in LoadFrom() has been replaced with code that registers itself with the parent object when the object is copied. Using Find() causes a problem where a second child with the same name cannot be found if it exists. This problem can be avoided by spontaneously registering the child.

OnParentage is divided into two parts.
In the individual objects, we are only deleting from the _childObjects of the old parent object.
The newly added function OnParentageRoot() adds children to the _childObjects of the new parent.

It may not check all cases, but it should be more stable. Maybe. 
Of the three commits, let me know if the back two are in danger. If they are in danger, I will revert.


