### PR TITLE
[VE] Added option to set export FPS

### DIFF
--- a/VideoExport.Core/Resources/English.xml
+++ b/VideoExport.Core/Resources/English.xml
@@ -2,6 +2,7 @@
   <string key="ScreenshotPlugin" value="Screenshot Plugin" />
   <string key="CurrentSize" value="Current Size" />
   <string key="Framerate" value="Framerate" />
+  <string key="ExportFramerate" value="Export Framerate" />
   <string key="AutoGenerateVideo" value="Auto Generate Video" />
   <string key="AutoDeleteImages" value="Auto Delete Images" />
   <string key="LimitBy" value="Limit By" />

--- a/VideoExport.Core/Resources/中文.xml
+++ b/VideoExport.Core/Resources/中文.xml
@@ -2,6 +2,7 @@
   <string key="ScreenshotPlugin" value="屏幕截图插件" />
   <string key="CurrentSize" value="当前尺寸" />
   <string key="Framerate" value="帧率" />
+  <string key="ExportFramerate" value="导出帧率" />
   <string key="AutoGenerateVideo" value="自动生成视频" />
   <string key="AutoDeleteImages" value="自动删除图片" />
   <string key="LimitBy" value="限制" />

--- a/VideoExport.Core/VideoExport.cs
+++ b/VideoExport.Core/VideoExport.cs
@@ -384,6 +384,7 @@ namespace VideoExport
             base.OnDestroy();
             _configFile.SetInt("selectedScreenshotPlugin", _selectedPlugin);
             _configFile.SetInt("framerate", _fps);
+            _configFile.SetInt("exportFramerate", _exportFps);
             _configFile.SetBool("autoGenerateVideo", _autoGenerateVideo);
             _configFile.SetBool("autoDeleteImages", _autoDeleteImages);
             _configFile.SetBool("limitDuration", _limitDuration);

--- a/VideoExport.Core/VideoExport.cs
+++ b/VideoExport.Core/VideoExport.cs
@@ -71,6 +71,7 @@ namespace VideoExport
             ScreenshotPlugin,
             CurrentSize,
             Framerate,
+            ExportFramerate,
             AutoGenerateVideo,
             AutoDeleteImages,
             LimitBy,
@@ -206,6 +207,7 @@ namespace VideoExport
 
         private int _selectedPlugin = 0;
         private int _fps = 60;
+        private int _exportFps = 60;
         private bool _autoGenerateVideo;
         private bool _autoDeleteImages;
         private bool _limitDuration;
@@ -250,6 +252,7 @@ namespace VideoExport
             _configFile = new GenericConfig(Name, this);
             _selectedPlugin = _configFile.AddInt("selectedScreenshotPlugin", 0, true);
             _fps = _configFile.AddInt("framerate", 60, true);
+            _exportFps = _configFile.AddInt("exportFramerate", 60, true);
             _autoGenerateVideo = _configFile.AddBool("autoGenerateVideo", true, true);
             _autoDeleteImages = _configFile.AddBool("autoDeleteImages", true, true);
             _limitDuration = _configFile.AddBool("limitDuration", false, true);
@@ -463,6 +466,27 @@ namespace VideoExport
                     if (int.TryParse(s, out res) == false || res < 1)
                         res = 1;
                     _fps = res;
+                }
+                GUILayout.EndHorizontal();
+
+                GUILayout.BeginHorizontal();
+                {
+                    GUILayout.Label(_currentDictionary.GetString(TranslationKey.ExportFramerate), GUILayout.ExpandWidth(false));
+                    _exportFps = Mathf.RoundToInt(GUILayout.HorizontalSlider(Mathf.Clamp(_exportFps, 1, _fps), 1, _fps));
+                    string s = GUILayout.TextField(_exportFps.ToString(), GUILayout.Width(50));
+                    int res;
+                    if (int.TryParse(s, out res) == false || res < 1)
+                        res = 1;
+
+                    //multiply by fps
+                    for (int d = 1; d <= _fps; ++d)
+                        if (_fps % d == 0 && res <= d)
+                        {
+                            res = d;
+                            break;
+                        }
+
+                    _exportFps = res;
                 }
                 GUILayout.EndHorizontal();
 
@@ -918,6 +942,7 @@ namespace VideoExport
             {
                 _recordingFrameLimit = -1;
             }
+            int exportInterval = _fps / _exportFps;
             TimeSpan elapsed = TimeSpan.Zero;
             int i = 0;
             string imageExtension = screenshotPlugin.extension;
@@ -936,10 +961,14 @@ namespace VideoExport
                     Resources.UnloadUnusedAssets();
                     GC.Collect();
                 }
-                string savePath = Path.Combine(framesFolder, $"{_imagesPrefix}{i}{_imagesPostfix}.{imageExtension}");
-                byte[] frame = screenshotPlugin.Capture(savePath);
-                if (frame != null)
-                    File.WriteAllBytes(savePath, frame);
+
+                if(i % exportInterval == 0 )
+                {
+                    string savePath = Path.Combine(framesFolder, $"{_imagesPrefix}{i / exportInterval}{_imagesPostfix}.{imageExtension}");
+                    byte[] frame = screenshotPlugin.Capture(savePath);
+                    if (frame != null)
+                        File.WriteAllBytes(savePath, frame);
+                }
 
                 elapsed = DateTime.Now - startTime;
 
@@ -981,7 +1010,7 @@ namespace VideoExport
                 yield return null;
                 IExtension extension = _extensions[(int)_selectedExtension];
 
-                string arguments = extension.GetArguments(SimplifyPath(framesFolder), _imagesPrefix, _imagesPostfix, imageExtension, screenshotPlugin.bitDepth, _fps, screenshotPlugin.transparency, _resize, _resizeX, _resizeY, SimplifyPath(Path.Combine(_outputFolder, tempName)));
+                string arguments = extension.GetArguments(SimplifyPath(framesFolder), _imagesPrefix, _imagesPostfix, imageExtension, screenshotPlugin.bitDepth, _exportFps, screenshotPlugin.transparency, _resize, _resizeX, _resizeY, SimplifyPath(Path.Combine(_outputFolder, tempName)));
                 startTime = DateTime.Now;
                 Process proc = StartExternalProcess(extension.GetExecutable(), arguments, extension.canProcessStandardOutput, extension.canProcessStandardError);
                 while (proc.HasExited == false)


### PR DESCRIPTION
Added option to set export FPS. Please merge if it looks OK.
![image](https://github.com/IllusionMods/HSPlugins/assets/4230203/2ff6378e-f915-445f-ad62-4d953e069214)

The combination of IK, NodesConstraints and animations can result in unnatural motion when outputting video at low FPS.
The following video has a hand pinned to another character's chest with NodeConstraints. Can you see how the hands sometimes slide unnaturally at low FPS (2) and (3)?
Avoid this by capturing at high FPS and exporting at low FPS.

To be correct, slides do occur at high FPS, but they are not noticeable because of their small volume.
Apparently some things don't work well when deltaTime is large.


① 15FPS from 60FPS:

https://github.com/IllusionMods/HSPlugins/assets/4230203/40ff4091-c44b-4cba-b3ae-e8bfe4f1811e

② 15FPS:

https://github.com/IllusionMods/HSPlugins/assets/4230203/b7a9f0cd-e3a3-4337-858c-f72fd4a779f6

③ 30FPS:

https://github.com/IllusionMods/HSPlugins/assets/4230203/6550fe18-7d9e-4c28-8074-60b214e929c4

④ 60FPS:

https://github.com/IllusionMods/HSPlugins/assets/4230203/69580c30-309f-4f9b-99cd-b6bcf2bc7cab


