### PR TITLE
[NC] Add contraint change factors, movement dampening and variable axis locking

### DIFF
--- a/NodesConstraints.Core/NodesConstraints.cs
+++ b/NodesConstraints.Core/NodesConstraints.cs
@@ -919,6 +919,8 @@ namespace NodesConstraints
                                         // https://docs.unity3d.com/ScriptReference/Quaternion.LookRotation.html
                                         var relativePos = _displayedConstraint.parentTransform.position - _displayedConstraint.childTransform.position;
                                         var lookAtRot = Quaternion.LookRotation(relativePos);
+                                        if (_displayedConstraint.mirrorRotation)
+                                            lookAtRot = new Quaternion(lookAtRot.x * -1f, lookAtRot.y * -1f, lookAtRot.z, lookAtRot.w);
                                         // Same as the no LookAt version below, just using the LookAt rotation the child would have without offsets as baseline for getting the offset
                                         _displayedConstraint.rotationOffset = Quaternion.Inverse(lookAtRot) * _displayedConstraint.childTransform.rotation;
                                     }

--- a/NodesConstraints.Core/NodesConstraints.cs
+++ b/NodesConstraints.Core/NodesConstraints.cs
@@ -844,31 +844,38 @@ namespace NodesConstraints
         {
             void DrawLinkRow(string transform, ref bool enabled, ref bool mirror, ref string xStr, ref string yStr, ref string zStr, ref string factorStr, ref string dampStr, Action onUseCurrent, Action onReset)
             {
+                GUI.enabled = _displayedConstraint.parentTransform != null && _displayedConstraint.childTransform != null;
                 GUILayout.BeginHorizontal();
                 {
-                    GUI.enabled = _displayedConstraint.parentTransform != null && _displayedConstraint.childTransform != null;
                     enabled = GUILayout.Toggle(enabled && _displayedConstraint.childTransform != null, $"Link {transform}");
                     GUILayout.FlexibleSpace();
-                    if (transform == "rotation")
-                        _displayedConstraint.lookAt = GUILayout.Toggle(_displayedConstraint.lookAt, "Look At");
-                    mirror = GUILayout.Toggle(mirror, "Mirror");
                     GUILayout.Label("X", GUILayout.ExpandWidth(false));
                     xStr = GUILayout.TextField(xStr, GUILayout.Width(50));
                     GUILayout.Label("Y");
                     yStr = GUILayout.TextField(yStr, GUILayout.Width(50));
                     GUILayout.Label("Z");
                     zStr = GUILayout.TextField(zStr, GUILayout.Width(50));
-                    GUILayout.Label("Factor");
-                    factorStr = GUILayout.TextField(factorStr, GUILayout.Width(50));
-                    GUILayout.Label("Damp");
-                    dampStr = GUILayout.TextField(dampStr, GUILayout.Width(50));
                     if (GUILayout.Button("Use current", GUILayout.ExpandWidth(false)))
                         onUseCurrent();
                     if (GUILayout.Button("Reset", GUILayout.ExpandWidth(false)))
                         onReset();
-                    GUI.enabled = true;
                 }
                 GUILayout.EndHorizontal();
+
+                GUILayout.BeginHorizontal();
+                {
+                    GUILayout.FlexibleSpace();
+                    if (transform == "rotation")
+                        _displayedConstraint.lookAt = GUILayout.Toggle(_displayedConstraint.lookAt, "Look At");
+                    mirror = GUILayout.Toggle(mirror, "Mirror");
+                    GUILayout.Label(" | ");
+                    GUILayout.Label("Factor");
+                    factorStr = GUILayout.TextField(factorStr, GUILayout.Width(50));
+                    GUILayout.Label("Damp");
+                    dampStr = GUILayout.TextField(dampStr, GUILayout.Width(50));
+                }
+                GUILayout.EndHorizontal();
+                GUI.enabled = true;
             }
 
             GUILayout.BeginVertical();

--- a/NodesConstraints.Core/NodesConstraints.cs
+++ b/NodesConstraints.Core/NodesConstraints.cs
@@ -1807,6 +1807,33 @@ namespace NodesConstraints
                             XmlConvert.ToSingle(childNode.Attributes["originalParentScaleY"].Value),
                             XmlConvert.ToSingle(childNode.Attributes["originalParentScaleZ"].Value)
                         );
+                    // All added in the same update, so should alwasy exist if one of them is not null
+                    if (childNode.Attributes["positionChangeFactor"] != null)
+                    {
+                        c.positionChangeFactor = XmlConvert.ToSingle(childNode.Attributes["positionChangeFactor"].Value);
+                        c.rotationChangeFactor = XmlConvert.ToSingle(childNode.Attributes["rotationChangeFactor"].Value);
+                        c.scaleChangeFactor = XmlConvert.ToSingle(childNode.Attributes["scaleChangeFactor"].Value);
+
+                        c.positionDamp = XmlConvert.ToSingle(childNode.Attributes["positionDamp"].Value);
+                        c.rotationDamp = XmlConvert.ToSingle(childNode.Attributes["rotationDamp"].Value);
+                        c.scaleDamp = XmlConvert.ToSingle(childNode.Attributes["scaleDamp"].Value);
+
+                        c.positionLocks = new TransformLock(
+                            XmlConvert.ToBoolean(childNode.Attributes["positionLocksX"].Value),
+                            XmlConvert.ToBoolean(childNode.Attributes["positionLocksY"].Value),
+                            XmlConvert.ToBoolean(childNode.Attributes["positionLocksZ"].Value)
+                        );
+                        c.rotationLocks = new TransformLock(
+                            XmlConvert.ToBoolean(childNode.Attributes["rotationLocksX"].Value),
+                            XmlConvert.ToBoolean(childNode.Attributes["rotationLocksY"].Value),
+                            XmlConvert.ToBoolean(childNode.Attributes["rotationLocksZ"].Value)
+                        );
+                        c.scaleLocks = new TransformLock(
+                            XmlConvert.ToBoolean(childNode.Attributes["scaleLocksX"].Value),
+                            XmlConvert.ToBoolean(childNode.Attributes["scaleLocksY"].Value),
+                            XmlConvert.ToBoolean(childNode.Attributes["scaleLocksZ"].Value)
+                        );
+                    }
                 }
             }
         }
@@ -2002,6 +2029,26 @@ namespace NodesConstraints
                 xmlWriter.WriteAttributeString("originalParentScaleX", XmlConvert.ToString(constraint.originalParentScale.x));
                 xmlWriter.WriteAttributeString("originalParentScaleY", XmlConvert.ToString(constraint.originalParentScale.y));
                 xmlWriter.WriteAttributeString("originalParentScaleZ", XmlConvert.ToString(constraint.originalParentScale.z));
+
+                xmlWriter.WriteAttributeString("positionChangeFactor", XmlConvert.ToString(constraint.positionChangeFactor));
+                xmlWriter.WriteAttributeString("rotationChangeFactor", XmlConvert.ToString(constraint.rotationChangeFactor));
+                xmlWriter.WriteAttributeString("scaleChangeFactor", XmlConvert.ToString(constraint.scaleChangeFactor));
+
+                xmlWriter.WriteAttributeString("positionDamp", XmlConvert.ToString(constraint.positionDamp));
+                xmlWriter.WriteAttributeString("rotationDamp", XmlConvert.ToString(constraint.rotationDamp));
+                xmlWriter.WriteAttributeString("scaleDamp", XmlConvert.ToString(constraint.scaleDamp));
+
+                xmlWriter.WriteAttributeString("positionLocksX", XmlConvert.ToString(constraint.positionLocks.x));
+                xmlWriter.WriteAttributeString("positionLocksY", XmlConvert.ToString(constraint.positionLocks.y));
+                xmlWriter.WriteAttributeString("positionLocksZ", XmlConvert.ToString(constraint.positionLocks.z));
+
+                xmlWriter.WriteAttributeString("rotationLocksX", XmlConvert.ToString(constraint.rotationLocks.x));
+                xmlWriter.WriteAttributeString("rotationLocksY", XmlConvert.ToString(constraint.rotationLocks.y));
+                xmlWriter.WriteAttributeString("rotationLocksZ", XmlConvert.ToString(constraint.rotationLocks.z));
+
+                xmlWriter.WriteAttributeString("scaleLocksX", XmlConvert.ToString(constraint.scaleLocks.x));
+                xmlWriter.WriteAttributeString("scaleLocksY", XmlConvert.ToString(constraint.scaleLocks.y));
+                xmlWriter.WriteAttributeString("scaleLocksZ", XmlConvert.ToString(constraint.scaleLocks.z));
 
                 xmlWriter.WriteAttributeString("alias", constraint.alias);
                 xmlWriter.WriteAttributeString("dynamic", XmlConvert.ToString(constraint.fixDynamicBone));

--- a/NodesConstraints.Core/NodesConstraints.cs
+++ b/NodesConstraints.Core/NodesConstraints.cs
@@ -213,9 +213,7 @@ namespace NodesConstraints
 
             public Quaternion GetRotationChange()
             {
-                var rot = Quaternion.Inverse(originalParentRotation) * parentTransform.rotation;
-                //TODO: Fix when movement over 180 degrees snapping
-                return Quaternion.Euler(rot.eulerAngles.x * rotationChangeFactor, rot.eulerAngles.y * rotationChangeFactor, rot.eulerAngles.z * rotationChangeFactor);
+                return Quaternion.Inverse(originalParentRotation) * parentTransform.rotation;
             }
 
             public void UpdateRotation()
@@ -236,6 +234,7 @@ namespace NodesConstraints
                 else
                     targetRot = originalParentRotation * GetRotationChange() * rotationOffset;
                 targetRot *= rotationOffset;
+                targetRot = Quaternion.SlerpUnclamped(Quaternion.identity, targetRot, rotationChangeFactor);
 
                 targetRot = Quaternion.Euler(
                         rotationLocks.x ? targetRot.eulerAngles.x : childTransform.rotation.eulerAngles.x,

--- a/NodesConstraints.Core/NodesConstraints.cs
+++ b/NodesConstraints.Core/NodesConstraints.cs
@@ -89,29 +89,37 @@ namespace NodesConstraints
         private class Constraint
         {
             public bool enabled = true;
+
             public GuideObject parent;
             public Transform parentTransform;
             public GuideObject child;
             public Transform childTransform;
+
             public bool position = true;
-            public bool mirrorPosition = false;
-            public float positionChangeFactor = 1;
-            public float positionDamp = 0;
             public bool rotation = true;
-            public bool mirrorRotation = false;
-            public float rotationChangeFactor = 1;
-            public float rotationDamp = 0;
             public bool lookAt = false;
             public bool scale = true;
+
+            public bool mirrorPosition = false;
+            public bool mirrorRotation = false;
             public bool mirrorScale = false;
+
+            public float positionChangeFactor = 1;
+            public float rotationChangeFactor = 1;
             public float scaleChangeFactor = 1;
+
+            public float positionDamp = 0;
+            public float rotationDamp = 0;
             public float scaleDamp = 0;
+
             public Vector3 positionOffset = Vector3.zero;
             public Quaternion rotationOffset = Quaternion.identity;
             public Vector3 scaleOffset = Vector3.one;
+
             public Vector3 originalChildPosition;
             public Quaternion originalChildRotation;
             public Vector3 originalChildScale;
+
             public string alias = "";
             public bool fixDynamicBone;
             public int? uniqueLoadId;
@@ -165,6 +173,11 @@ namespace NodesConstraints
                 _debugLine.Draw();
             }
 
+            public float GetInterpolationFactor(float damp)
+            {
+                return 1 - Mathf.Exp(-damp * Time.deltaTime);
+            }
+
             public Vector3 GetPositionMovement()
             {
                 return (parentTransform.position - originalParentPosition) * positionChangeFactor;
@@ -180,7 +193,7 @@ namespace NodesConstraints
                 targetPos += positionOffset;
 
                 if (positionDamp > 0)
-                    targetPos = Vector3.Lerp(childTransform.position, targetPos, 1 - Mathf.Exp(-positionDamp * Time.deltaTime));
+                        targetPos = Vector3.Lerp(childTransform.position, targetPos, GetInterpolationFactor(positionDamp));
                 childTransform.position = targetPos;
 
                 if (child != null)
@@ -214,7 +227,7 @@ namespace NodesConstraints
                 targetRot *= rotationOffset;
 
                 if (rotationDamp > 0)
-                    targetRot = Quaternion.Slerp(childTransform.rotation, targetRot, 1 - Mathf.Exp(-rotationDamp * Time.deltaTime));
+                    targetRot = Quaternion.Slerp(childTransform.rotation, targetRot, GetInterpolationFactor(rotationDamp));
                 childTransform.rotation = targetRot;
 
                 if (child != null)
@@ -244,7 +257,7 @@ namespace NodesConstraints
                         (originalParentScale.x * scaleOffset.y) * ((parentTransform.lossyScale.y - originalParentScale.y) / originalParentScale.y * scaleChangeFactor + 1),
                         (originalParentScale.x * scaleOffset.z) * ((parentTransform.lossyScale.z - originalParentScale.z) / originalParentScale.z * scaleChangeFactor + 1)
                     );
-                childTransform.localScale = Vector3.Lerp(childTransform.localScale, targetScale, 1 - Mathf.Exp(-scaleDamp * Time.deltaTime));
+                childTransform.localScale = Vector3.Lerp(childTransform.localScale, targetScale, GetInterpolationFactor(scaleDamp));
                 if (child != null)
                     child.changeAmount.scale = child.transformTarget.localScale;
             }
@@ -313,21 +326,25 @@ namespace NodesConstraints
         private int _totalActiveExpressions = 0;
         private int _currentExpressionIndex = 0;
         private readonly HashSet<Expression> _allExpressions = new HashSet<Expression>();
+
         private string _positionXStr = "0.0000";
         private string _positionYStr = "0.0000";
         private string _positionZStr = "0.0000";
         private string _positionFactorStr = "1.0000";
         private string _positionDampStr = "0.000";
+
         private string _rotationXStr = "0.000";
         private string _rotationYStr = "0.000";
         private string _rotationZStr = "0.000";
         private string _rotationFactorStr = "1.0000";
         private string _rotationDampStr = "0.000";
+
         private string _scaleXStr = "1.0000";
         private string _scaleYStr = "1.0000";
         private string _scaleZStr = "1.0000";
         private string _scaleFactorStr = "1.0000";
         private string _scaleDampStr = "0.000";
+
         private bool _debugMode;
         private Vector3 _debugLocalPosition;
         private Vector3 _debugWorldPosition;
@@ -867,7 +884,7 @@ namespace NodesConstraints
                     GUILayout.FlexibleSpace();
                     if (transform == "rotation")
                         _displayedConstraint.lookAt = GUILayout.Toggle(_displayedConstraint.lookAt, "Look At");
-                    mirror = GUILayout.Toggle(mirror, "Mirror");
+                    mirror = GUILayout.Toggle(mirror, "Mirror", "Button");
                     GUILayout.Label(" | ");
                     GUILayout.Label("Factor");
                     factorStr = GUILayout.TextField(factorStr, GUILayout.Width(50));

--- a/NodesConstraints.Core/NodesConstraints.cs
+++ b/NodesConstraints.Core/NodesConstraints.cs
@@ -828,6 +828,33 @@ namespace NodesConstraints
 
         private void WindowFunction(int id)
         {
+            void DrawLinkRow(string transform, ref bool enabled, ref bool mirror, ref string xStr, ref string yStr, ref string zStr, ref string factorStr, Action onUseCurrent, Action onReset)
+            {
+                GUILayout.BeginHorizontal();
+                {
+                    GUI.enabled = _displayedConstraint.parentTransform != null && _displayedConstraint.childTransform != null;
+                    enabled = GUILayout.Toggle(enabled && _displayedConstraint.childTransform != null, $"Link {transform}");
+                    GUILayout.FlexibleSpace();
+                    if (transform == "rotation")
+                        _displayedConstraint.lookAt = GUILayout.Toggle(_displayedConstraint.lookAt, "Look At");
+                    mirror = GUILayout.Toggle(mirror, "Mirror");
+                    GUILayout.Label("X", GUILayout.ExpandWidth(false));
+                    xStr = GUILayout.TextField(xStr, GUILayout.Width(50));
+                    GUILayout.Label("Y");
+                    yStr = GUILayout.TextField(yStr, GUILayout.Width(50));
+                    GUILayout.Label("Z");
+                    zStr = GUILayout.TextField(zStr, GUILayout.Width(50));
+                    GUILayout.Label("Factor");
+                    factorStr = GUILayout.TextField(factorStr, GUILayout.Width(50));
+                    if (GUILayout.Button("Use current", GUILayout.ExpandWidth(false)))
+                        onUseCurrent();
+                    if (GUILayout.Button("Reset", GUILayout.ExpandWidth(false)))
+                        onReset();
+                    GUI.enabled = true;
+                }
+                GUILayout.EndHorizontal();
+            }
+
             GUILayout.BeginVertical();
             {
                 GUILayout.BeginHorizontal();
@@ -844,48 +871,23 @@ namespace NodesConstraints
                         }
                         GUILayout.EndHorizontal();
 
-
-                        GUILayout.BeginHorizontal();
-                        {
-                            GUI.enabled = _displayedConstraint.parentTransform != null && _displayedConstraint.childTransform != null;
-                            _displayedConstraint.position = GUILayout.Toggle(_displayedConstraint.position && _displayedConstraint.childTransform != null, "Link position");
-                            GUILayout.FlexibleSpace();
-                            _displayedConstraint.mirrorPosition = GUILayout.Toggle(_displayedConstraint.mirrorPosition, "Mirror");
-                            GUILayout.Label("X", GUILayout.ExpandWidth(false));
-                            _positionXStr = GUILayout.TextField(_positionXStr, GUILayout.Width(50));
-                            GUILayout.Label("Y");
-                            _positionYStr = GUILayout.TextField(_positionYStr, GUILayout.Width(50));
-                            GUILayout.Label("Z");
-                            _positionZStr = GUILayout.TextField(_positionZStr, GUILayout.Width(50));
-                            if (GUILayout.Button("Use current", GUILayout.ExpandWidth(false)))
+                        DrawLinkRow("position", ref _displayedConstraint.position, ref _displayedConstraint.mirrorPosition, ref _positionXStr, ref _positionYStr, ref _positionZStr, ref _positionFactorStr,
+                            () =>
+                            {
                                 _onPreCullAction = () =>
                                 {
                                     _displayedConstraint.positionOffset = _displayedConstraint.parentTransform.InverseTransformPoint(_displayedConstraint.childTransform.position);
                                     UpdateDisplayedPositionOffset();
                                 };
-                            if (GUILayout.Button("Reset", GUILayout.ExpandWidth(false)))
+                            },
+                            () =>
                             {
                                 _displayedConstraint.positionOffset = Vector3.zero;
                                 UpdateDisplayedPositionOffset();
-                            }
-                            GUI.enabled = true;
-                        }
-                        GUILayout.EndHorizontal();
+                            });
 
-                        GUILayout.BeginHorizontal();
-                        {
-                            GUI.enabled = _displayedConstraint.parentTransform != null && _displayedConstraint.childTransform != null;
-                            _displayedConstraint.rotation = GUILayout.Toggle(_displayedConstraint.rotation && _displayedConstraint.childTransform != null, "Link rotation");
-                            GUILayout.FlexibleSpace();
-                            _displayedConstraint.lookAt = GUILayout.Toggle(_displayedConstraint.lookAt, "Look At");
-                            _displayedConstraint.mirrorRotation = GUILayout.Toggle(_displayedConstraint.mirrorRotation, "Mirror");
-                            GUILayout.Label("X", GUILayout.ExpandWidth(false));
-                            _rotationXStr = GUILayout.TextField(_rotationXStr, GUILayout.Width(50));
-                            GUILayout.Label("Y", GUILayout.ExpandWidth(false));
-                            _rotationYStr = GUILayout.TextField(_rotationYStr, GUILayout.Width(50));
-                            GUILayout.Label("Z", GUILayout.ExpandWidth(false));
-                            _rotationZStr = GUILayout.TextField(_rotationZStr, GUILayout.Width(50));
-                            if (GUILayout.Button("Use current", GUILayout.ExpandWidth(false)))
+                        DrawLinkRow("rotation", ref _displayedConstraint.rotation, ref _displayedConstraint.mirrorRotation, ref _rotationXStr, ref _rotationYStr, ref _rotationZStr, ref _rotationFactorStr,
+                            () =>
                             {
                                 _onPreCullAction = () =>
                                 {
@@ -901,29 +903,16 @@ namespace NodesConstraints
                                         _displayedConstraint.rotationOffset = Quaternion.Inverse(_displayedConstraint.parentTransform.rotation) * _displayedConstraint.childTransform.rotation;
                                     UpdateDisplayedRotationOffset();
                                 };
-                            }
-                            if (GUILayout.Button("Reset", GUILayout.ExpandWidth(false)))
+                            },
+                            () =>
                             {
                                 _displayedConstraint.rotationOffset = Quaternion.identity;
                                 UpdateDisplayedRotationOffset();
-                            }
-                            GUI.enabled = true;
-                        }
-                        GUILayout.EndHorizontal();
+                            });
 
-                        GUILayout.BeginHorizontal();
-                        {
-                            GUI.enabled = _displayedConstraint.parentTransform != null && _displayedConstraint.childTransform != null;
-                            _displayedConstraint.scale = GUILayout.Toggle(_displayedConstraint.scale && _displayedConstraint.childTransform != null, "Link scale");
-                            GUILayout.FlexibleSpace();
-                            _displayedConstraint.mirrorScale = GUILayout.Toggle(_displayedConstraint.mirrorScale, "Mirror");
-                            GUILayout.Label("X", GUILayout.ExpandWidth(false));
-                            _scaleXStr = GUILayout.TextField(_scaleXStr, GUILayout.Width(50));
-                            GUILayout.Label("Y");
-                            _scaleYStr = GUILayout.TextField(_scaleYStr, GUILayout.Width(50));
-                            GUILayout.Label("Z");
-                            _scaleZStr = GUILayout.TextField(_scaleZStr, GUILayout.Width(50));
-                            if (GUILayout.Button("Use current", GUILayout.ExpandWidth(false)))
+                        DrawLinkRow("scale", ref _displayedConstraint.scale, ref _displayedConstraint.mirrorScale, ref _scaleXStr, ref _scaleYStr, ref _scaleZStr, ref _scaleFactorStr,
+                            () =>
+                            {
                                 _onPreCullAction = () =>
                                 {
                                     _displayedConstraint.scaleOffset = new Vector3(
@@ -933,14 +922,12 @@ namespace NodesConstraints
                                     );
                                     UpdateDisplayedScaleOffset();
                                 };
-                            if (GUILayout.Button("Reset", GUILayout.ExpandWidth(false)))
+                            },
+                            () =>
                             {
                                 _displayedConstraint.scaleOffset = Vector3.one;
                                 UpdateDisplayedScaleOffset();
-                            }
-                            GUI.enabled = true;
-                        }
-                        GUILayout.EndHorizontal();
+                            });
 
                         GUILayout.BeginHorizontal();
                         {
@@ -960,7 +947,7 @@ namespace NodesConstraints
                                 ValidateDisplayedRotationOffset();
                                 ValidateDisplayedScaleOffset();
 
-                                var newConstraint = AddConstraint(true, _displayedConstraint.parentTransform, _displayedConstraint.childTransform, _displayedConstraint.position, _displayedConstraint.mirrorPosition, _displayedConstraint.positionOffset, _displayedConstraint.rotation, _displayedConstraint.mirrorRotation, _displayedConstraint.lookAt, _displayedConstraint.rotationOffset, _displayedConstraint.scale, _displayedConstraint.mirrorScale, _displayedConstraint.scaleOffset, _displayedConstraint.alias);
+                                var newConstraint = AddConstraint(true, _displayedConstraint.parentTransform, _displayedConstraint.childTransform, _displayedConstraint.position, _displayedConstraint.mirrorPosition, _displayedConstraint.positionOffset, _displayedConstraint.rotation, _displayedConstraint.mirrorRotation, _displayedConstraint.lookAt, _displayedConstraint.rotationOffset, _displayedConstraint.scale, _displayedConstraint.mirrorScale, _displayedConstraint.scaleOffset, _displayedConstraint.alias, _displayedConstraint.positionChangeFactor, _displayedConstraint.rotationChangeFactor, _displayedConstraint.scaleChangeFactor);
 
                                 if (newConstraint != null)
                                 {
@@ -1001,11 +988,14 @@ namespace NodesConstraints
                                     _selectedConstraint.child = null;
                                 _selectedConstraint.position = _displayedConstraint.position;
                                 _selectedConstraint.mirrorPosition = _displayedConstraint.mirrorPosition;
+                                _selectedConstraint.positionChangeFactor = _displayedConstraint.positionChangeFactor;
                                 _selectedConstraint.rotation = _displayedConstraint.rotation;
                                 _selectedConstraint.mirrorRotation = _displayedConstraint.mirrorRotation;
+                                _selectedConstraint.rotationChangeFactor = _displayedConstraint.rotationChangeFactor;
                                 _selectedConstraint.lookAt = _displayedConstraint.lookAt;
                                 _selectedConstraint.scale = _displayedConstraint.scale;
                                 _selectedConstraint.mirrorScale = _displayedConstraint.mirrorScale;
+                                _selectedConstraint.scaleChangeFactor = _displayedConstraint.scaleChangeFactor;
                                 _selectedConstraint.positionOffset = _displayedConstraint.positionOffset;
                                 _selectedConstraint.rotationOffset = _displayedConstraint.rotationOffset;
                                 _selectedConstraint.scaleOffset = _displayedConstraint.scaleOffset;
@@ -1095,11 +1085,14 @@ namespace NodesConstraints
                                 _displayedConstraint.childTransform = _selectedConstraint.childTransform;
                                 _displayedConstraint.position = _selectedConstraint.position;
                                 _displayedConstraint.mirrorPosition = _selectedConstraint.mirrorPosition;
+                                _displayedConstraint.positionChangeFactor = _selectedConstraint.positionChangeFactor;
                                 _displayedConstraint.rotation = _selectedConstraint.rotation;
                                 _displayedConstraint.mirrorRotation = _selectedConstraint.mirrorRotation;
+                                _displayedConstraint.rotationChangeFactor = _selectedConstraint.rotationChangeFactor;
                                 _displayedConstraint.lookAt = _selectedConstraint.lookAt;
                                 _displayedConstraint.scale = _selectedConstraint.scale;
                                 _displayedConstraint.mirrorScale = _selectedConstraint.mirrorScale;
+                                _displayedConstraint.scaleChangeFactor = _selectedConstraint.scaleChangeFactor;
                                 _displayedConstraint.positionOffset = _selectedConstraint.positionOffset;
                                 _displayedConstraint.rotationOffset = _selectedConstraint.rotationOffset;
                                 _displayedConstraint.scaleOffset = _selectedConstraint.scaleOffset;
@@ -1307,6 +1300,7 @@ namespace NodesConstraints
             _positionXStr = _displayedConstraint.positionOffset.x.ToString("0.0000");
             _positionYStr = _displayedConstraint.positionOffset.y.ToString("0.0000");
             _positionZStr = _displayedConstraint.positionOffset.z.ToString("0.0000");
+            _positionFactorStr = _displayedConstraint.positionChangeFactor.ToString("0.0000");
         }
 
         private void ValidateDisplayedPositionOffset()
@@ -1329,6 +1323,7 @@ namespace NodesConstraints
             _rotationXStr = euler.x.ToString("0.000");
             _rotationYStr = euler.y.ToString("0.000");
             _rotationZStr = euler.z.ToString("0.000");
+            _rotationFactorStr = _displayedConstraint.rotationChangeFactor.ToString("0.0000");
         }
 
         private void ValidateDisplayedRotationOffset()
@@ -1355,6 +1350,7 @@ namespace NodesConstraints
             _scaleXStr = _displayedConstraint.scaleOffset.x.ToString("0.0000");
             _scaleYStr = _displayedConstraint.scaleOffset.y.ToString("0.0000");
             _scaleZStr = _displayedConstraint.scaleOffset.z.ToString("0.0000");
+            _scaleFactorStr = _displayedConstraint.scaleChangeFactor.ToString("0.0000");
         }
 
         private void ValidateDisplayedScaleOffset()

--- a/NodesConstraints.Core/NodesConstraints.cs
+++ b/NodesConstraints.Core/NodesConstraints.cs
@@ -179,7 +179,7 @@ namespace NodesConstraints
 
             public float GetInterpolationFactor(float damp)
             {
-                return 1 - Mathf.Exp(-damp * Time.deltaTime);
+                return 1 - Mathf.Exp(-damp * _deltaTime);
             }
 
             public Vector3 GetPositionMovement()
@@ -382,6 +382,8 @@ namespace NodesConstraints
         private Vector3 _debugLocalScale;
         private Vector3 _debugWorldScale;
         private bool _hasTimeline = false;
+
+        private static float _deltaTime;
         #endregion
 
         internal static ConfigEntry<KeyboardShortcut> ConfigMainWindowShortcut { get; private set; }
@@ -474,6 +476,10 @@ namespace NodesConstraints
 
         protected override void Update()
         {
+            //Contraints without GuideObject (e.g. bones) are updated through a postfix
+            //This postfix does not have access to Time.deltaTime because it's not an update method
+            //This postfix is however postfixed to an update method, so by saving the value here, it can be used there too
+            _deltaTime = Time.deltaTime;
             if (_studioLoaded == false)
                 return;
             _totalActiveExpressions = _allExpressions.Count(e => e.enabled && e.gameObject.activeInHierarchy);

--- a/NodesConstraints.Core/NodesConstraints.cs
+++ b/NodesConstraints.Core/NodesConstraints.cs
@@ -189,11 +189,11 @@ namespace NodesConstraints
 
             public void UpdatePosition()
             {
-                Vector3 targetPos = Vector3.zero;
+                Vector3 targetPos;
                 if (mirrorPosition)
-                    targetPos -= GetPositionMovement() * (positionChangeFactor + 1);
+                    targetPos = -GetPositionMovement() * (positionChangeFactor + 1);
                 else
-                    targetPos += GetPositionMovement() * (positionChangeFactor - 1);
+                    targetPos = GetPositionMovement() * (positionChangeFactor - 1);
                 targetPos += positionOffset;
 
                 if (!positionLocks.x)
@@ -950,7 +950,7 @@ namespace NodesConstraints
                 {
                     GUILayout.BeginVertical();
                     {
-                        GUILayout.BeginHorizontal();
+                        GUILayout.BeginHorizontal(GUI.skin.box);
                         {
                             GUILayout.Label((_displayedConstraint.parentTransform != null ? _displayedConstraint.parentTransform.name : ""));
                             GUILayout.FlexibleSpace();

--- a/NodesConstraints.Core/NodesConstraints.cs
+++ b/NodesConstraints.Core/NodesConstraints.cs
@@ -370,6 +370,10 @@ namespace NodesConstraints
         private string _scaleFactorStr = "1.0000";
         private string _scaleDampStr = "0.000";
 
+        private bool showExtraMov = false;
+        private bool showExtraRot = false;
+        private bool showExtraScale = false;
+
         private bool _debugMode;
         private Vector3 _debugLocalPosition;
         private Vector3 _debugWorldPosition;
@@ -884,40 +888,52 @@ namespace NodesConstraints
 
         private void WindowFunction(int id)
         {
-            void DrawLinkRow(string transform, ref bool enabled, ref TransformLock locks, ref bool mirror, ref string xStr, ref string yStr, ref string zStr, ref string factorStr, ref string dampStr, Action onUseCurrent, Action onReset)
+            void DrawLinkRow(string transform, ref bool enabled, ref TransformLock locks, ref bool mirror, ref string xStr, ref string yStr, ref string zStr, ref string factorStr, ref string dampStr, ref bool showExtra, Action onUseCurrent, Action onReset)
             {
                 GUI.enabled = _displayedConstraint.parentTransform != null && _displayedConstraint.childTransform != null;
-                GUILayout.BeginHorizontal();
+                GUILayout.BeginVertical(GUI.skin.box);
                 {
-                    enabled = GUILayout.Toggle(enabled && _displayedConstraint.childTransform != null, $"Link {transform}");
-                    GUILayout.FlexibleSpace();
-                    //GUILayout.Label("X", GUILayout.ExpandWidth(false));
-                    locks.x = GUILayout.Toggle(locks.x, "X", "Button");
-                    xStr = GUILayout.TextField(xStr, GUILayout.Width(50));
-                    locks.y = GUILayout.Toggle(locks.y, "Y", "Button");
-                    yStr = GUILayout.TextField(yStr, GUILayout.Width(50));
-                    locks.z = GUILayout.Toggle(locks.z, "Z", "Button");
-                    zStr = GUILayout.TextField(zStr, GUILayout.Width(50));
-                    if (GUILayout.Button("Use current", GUILayout.ExpandWidth(false)))
-                        onUseCurrent();
-                    if (GUILayout.Button("Reset", GUILayout.ExpandWidth(false)))
-                        onReset();
-                }
-                GUILayout.EndHorizontal();
+                    GUILayout.BeginHorizontal();
+                    {
+                        enabled = GUILayout.Toggle(enabled && _displayedConstraint.childTransform != null, $"Link {transform}");
+                        GUILayout.FlexibleSpace();
+                        //GUILayout.Label("X", GUILayout.ExpandWidth(false));
+                        locks.x = GUILayout.Toggle(locks.x, "X", "Button");
+                        xStr = GUILayout.TextField(xStr, GUILayout.Width(50));
+                        locks.y = GUILayout.Toggle(locks.y, "Y", "Button");
+                        yStr = GUILayout.TextField(yStr, GUILayout.Width(50));
+                        locks.z = GUILayout.Toggle(locks.z, "Z", "Button");
+                        zStr = GUILayout.TextField(zStr, GUILayout.Width(50));
+                        if (GUILayout.Button("Use current", GUILayout.ExpandWidth(false)))
+                            onUseCurrent();
+                        if (GUILayout.Button("Reset", GUILayout.ExpandWidth(false)))
+                            onReset();
+                        if (GUILayout.Button(showExtra ? "▲" : "▼", GUILayout.ExpandWidth(false)))
+                            showExtra = !showExtra;
+                    }
+                    GUILayout.EndHorizontal();
 
-                GUILayout.BeginHorizontal();
-                {
-                    GUILayout.Label("   ↳");
-                    mirror = GUILayout.Toggle(mirror, "Mirror");
-                    if (transform == "rotation")
-                        _displayedConstraint.lookAt = GUILayout.Toggle(_displayedConstraint.lookAt, "Look At");
-                    GUILayout.FlexibleSpace();
-                    GUILayout.Label("Factor");
-                    factorStr = GUILayout.TextField(factorStr, GUILayout.Width(50));
-                    GUILayout.Label("Damp");
-                    dampStr = GUILayout.TextField(dampStr, GUILayout.Width(50));
+                    if (showExtra)
+                    {
+                        GUILayout.BeginHorizontal();
+                        {
+                            GUILayout.Label("↳");
+                            mirror = GUILayout.Toggle(mirror, "Mirror contraint");
+                            if (transform == "rotation")
+                            {
+                                GUILayout.Label(" | ");
+                                _displayedConstraint.lookAt = GUILayout.Toggle(_displayedConstraint.lookAt, "Look at parent");
+                            }
+                            GUILayout.FlexibleSpace();
+                            GUILayout.Label("Change factor");
+                            factorStr = GUILayout.TextField(factorStr, GUILayout.Width(50));
+                            GUILayout.Label("Dampen");
+                            dampStr = GUILayout.TextField(dampStr, GUILayout.Width(50));
+                        }
+                        GUILayout.EndHorizontal();
+                    }
                 }
-                GUILayout.EndHorizontal();
+                GUILayout.EndVertical();
                 GUI.enabled = true;
             }
 
@@ -937,7 +953,7 @@ namespace NodesConstraints
                         }
                         GUILayout.EndHorizontal();
 
-                        DrawLinkRow("position", ref _displayedConstraint.position, ref _displayedConstraint.positionLocks, ref _displayedConstraint.mirrorPosition, ref _positionXStr, ref _positionYStr, ref _positionZStr, ref _positionFactorStr, ref _positionDampStr,
+                        DrawLinkRow("position", ref _displayedConstraint.position, ref _displayedConstraint.positionLocks, ref _displayedConstraint.mirrorPosition, ref _positionXStr, ref _positionYStr, ref _positionZStr, ref _positionFactorStr, ref _positionDampStr, ref showExtraMov,
                             () =>
                             {
                                 _onPreCullAction = () =>
@@ -952,7 +968,7 @@ namespace NodesConstraints
                                 UpdateDisplayedPositionOffset();
                             });
 
-                        DrawLinkRow("rotation", ref _displayedConstraint.rotation, ref _displayedConstraint.rotationLocks, ref _displayedConstraint.mirrorRotation, ref _rotationXStr, ref _rotationYStr, ref _rotationZStr, ref _rotationFactorStr, ref _rotationDampStr,
+                        DrawLinkRow("rotation", ref _displayedConstraint.rotation, ref _displayedConstraint.rotationLocks, ref _displayedConstraint.mirrorRotation, ref _rotationXStr, ref _rotationYStr, ref _rotationZStr, ref _rotationFactorStr, ref _rotationDampStr, ref showExtraRot,
                             () =>
                             {
                                 _onPreCullAction = () =>
@@ -978,7 +994,7 @@ namespace NodesConstraints
                                 UpdateDisplayedRotationOffset();
                             });
 
-                        DrawLinkRow("scale", ref _displayedConstraint.scale, ref _displayedConstraint.scaleLocks, ref _displayedConstraint.mirrorScale, ref _scaleXStr, ref _scaleYStr, ref _scaleZStr, ref _scaleFactorStr, ref _scaleDampStr,
+                        DrawLinkRow("scale", ref _displayedConstraint.scale, ref _displayedConstraint.scaleLocks, ref _displayedConstraint.mirrorScale, ref _scaleXStr, ref _scaleYStr, ref _scaleZStr, ref _scaleFactorStr, ref _scaleDampStr, ref showExtraScale,
                             () =>
                             {
                                 _onPreCullAction = () =>

--- a/NodesConstraints.Core/NodesConstraints.cs
+++ b/NodesConstraints.Core/NodesConstraints.cs
@@ -184,16 +184,16 @@ namespace NodesConstraints
 
             public Vector3 GetPositionMovement()
             {
-                return (parentTransform.position - originalParentPosition) * positionChangeFactor;
+                return (parentTransform.position - originalParentPosition);
             }
 
             public void UpdatePosition()
             {
-                Vector3 targetPos;
+                Vector3 targetPos = Vector3.zero;
                 if (mirrorPosition)
-                    targetPos = originalParentPosition - GetPositionMovement();
+                    targetPos -= GetPositionMovement() * (positionChangeFactor + 1);
                 else
-                    targetPos = originalParentPosition + GetPositionMovement();
+                    targetPos += GetPositionMovement() * (positionChangeFactor - 1);
                 targetPos += positionOffset;
 
                 if (!positionLocks.x)
@@ -203,6 +203,7 @@ namespace NodesConstraints
                 if (!positionLocks.z)
                     targetPos.z = childTransform.position.z;
 
+                targetPos = parentTransform.TransformPoint(targetPos);
                 if (positionDamp > 0)
                     targetPos = Vector3.Lerp(childTransform.position, targetPos, GetInterpolationFactor(positionDamp));
                 childTransform.position = targetPos;
@@ -230,9 +231,9 @@ namespace NodesConstraints
                         targetRot = Quaternion.LookRotation(parentTransform.position - childTransform.position);
                 }
                 else if (mirrorRotation)
-                    targetRot = originalParentRotation * Quaternion.Inverse(GetRotationChange()) * rotationOffset;
+                    targetRot = originalParentRotation * Quaternion.Inverse(GetRotationChange());
                 else
-                    targetRot = originalParentRotation * GetRotationChange() * rotationOffset;
+                    targetRot = originalParentRotation * GetRotationChange();
                 targetRot *= rotationOffset;
                 targetRot = Quaternion.SlerpUnclamped(Quaternion.identity, targetRot, rotationChangeFactor);
 

--- a/NodesConstraints.Core/NodesConstraints.cs
+++ b/NodesConstraints.Core/NodesConstraints.cs
@@ -251,29 +251,13 @@ namespace NodesConstraints
                     child.changeAmount.rot = child.transformTarget.localEulerAngles;
             }
 
-            public Vector3 GetMirroredScale()
-            {
-                return new Vector3(
-                    // Multiply the original scale (+ any offsets) times the mirrored change factor compared to the original scale
-                    // mirroring the change factor is done by applying the power of -1 to the change factor
-                    (originalParentScale.x * scaleOffset.x) * Mathf.Pow((parentTransform.lossyScale.x - originalParentScale.x) / originalParentScale.x * scaleChangeFactor + 1, -1),
-                    (originalParentScale.y * scaleOffset.y) * Mathf.Pow((parentTransform.lossyScale.y - originalParentScale.y) / originalParentScale.y * scaleChangeFactor + 1, -1),
-                    (originalParentScale.z * scaleOffset.z) * Mathf.Pow((parentTransform.lossyScale.z - originalParentScale.z) / originalParentScale.z * scaleChangeFactor + 1, -1)
-                );
-            }
-
-            //TODO: Scaling using proper factor
             public void UpdateScale()
             {
-                Vector3 targetScale;
-                if (mirrorScale)
-                    targetScale = GetMirroredScale();
-                else
-                    targetScale = new Vector3(
-                        (originalParentScale.x * scaleOffset.x) * ((parentTransform.lossyScale.x - originalParentScale.x) / originalParentScale.x * scaleChangeFactor + 1),
-                        (originalParentScale.x * scaleOffset.y) * ((parentTransform.lossyScale.y - originalParentScale.y) / originalParentScale.y * scaleChangeFactor + 1),
-                        (originalParentScale.x * scaleOffset.z) * ((parentTransform.lossyScale.z - originalParentScale.z) / originalParentScale.z * scaleChangeFactor + 1)
-                    );
+                Vector3 targetScale = new Vector3(
+                    (originalParentScale.x * scaleOffset.x) * Mathf.Pow((parentTransform.lossyScale.x - originalParentScale.x) / originalParentScale.x + 1, mirrorScale ? -scaleChangeFactor : scaleChangeFactor),
+                    (originalParentScale.x * scaleOffset.y) * Mathf.Pow((parentTransform.lossyScale.y - originalParentScale.y) / originalParentScale.y + 1, mirrorScale ? -scaleChangeFactor : scaleChangeFactor),
+                    (originalParentScale.x * scaleOffset.z) * Mathf.Pow((parentTransform.lossyScale.z - originalParentScale.z) / originalParentScale.z + 1, mirrorScale ? -scaleChangeFactor : scaleChangeFactor)
+                );
 
                 if (!scaleLocks.x)
                     targetScale.x = childTransform.localScale.x;
@@ -282,7 +266,10 @@ namespace NodesConstraints
                 if (!scaleLocks.z)
                     targetScale.z = childTransform.localScale.z;
 
-                childTransform.localScale = Vector3.Lerp(childTransform.localScale, targetScale, GetInterpolationFactor(scaleDamp));
+                if (scaleDamp > 0)
+                    targetScale = Vector3.Lerp(childTransform.localScale, targetScale, GetInterpolationFactor(scaleDamp));
+                childTransform.localScale = targetScale;
+
                 if (child != null)
                     child.changeAmount.scale = child.transformTarget.localScale;
             }

--- a/NodesConstraints.Core/NodesConstraints.cs
+++ b/NodesConstraints.Core/NodesConstraints.cs
@@ -196,6 +196,8 @@ namespace NodesConstraints
                     targetPos = GetPositionMovement() * (positionChangeFactor - 1);
                 targetPos += positionOffset;
 
+                targetPos = parentTransform.TransformPoint(targetPos);
+
                 if (!positionLocks.x)
                     targetPos.x = childTransform.position.x;
                 if (!positionLocks.y)
@@ -203,7 +205,6 @@ namespace NodesConstraints
                 if (!positionLocks.z)
                     targetPos.z = childTransform.position.z;
 
-                targetPos = parentTransform.TransformPoint(targetPos);
                 if (positionDamp > 0)
                     targetPos = Vector3.Lerp(childTransform.position, targetPos, GetInterpolationFactor(positionDamp));
                 childTransform.position = targetPos;
@@ -292,6 +293,11 @@ namespace NodesConstraints
                 this.x = x;
                 this.y = y;
                 this.z = z;
+            }
+
+            public TransformLock Copy()
+            {
+                return new TransformLock(x, y, z);
             }
         }
 
@@ -1099,9 +1105,9 @@ namespace NodesConstraints
                                 _selectedConstraint.alias = _displayedConstraint.alias;
                                 _selectedConstraint.fixDynamicBone = _displayedConstraint.fixDynamicBone;
 
-                                _selectedConstraint.positionLocks = _displayedConstraint.positionLocks;
-                                _selectedConstraint.rotationLocks = _displayedConstraint.rotationLocks;
-                                _selectedConstraint.scaleLocks = _displayedConstraint.scaleLocks;
+                                _selectedConstraint.positionLocks = _displayedConstraint.positionLocks.Copy();
+                                _selectedConstraint.rotationLocks = _displayedConstraint.rotationLocks.Copy();
+                                _selectedConstraint.scaleLocks = _displayedConstraint.scaleLocks.Copy();
                                 TimelineCompatibility.RefreshInterpolablesList();
                             }
                             GUI.enabled = true;
@@ -1196,6 +1202,9 @@ namespace NodesConstraints
                                 _displayedConstraint.scaleOffset = _selectedConstraint.scaleOffset;
                                 _displayedConstraint.alias = _selectedConstraint.alias;
                                 _displayedConstraint.fixDynamicBone = _selectedConstraint.fixDynamicBone;
+                                _displayedConstraint.positionLocks = _selectedConstraint.positionLocks.Copy();
+                                _displayedConstraint.rotationLocks = _selectedConstraint.rotationLocks.Copy();
+                                _displayedConstraint.scaleLocks = _selectedConstraint.scaleLocks.Copy();
                                 UpdateDisplayedPositionOffset();
                                 UpdateDisplayedRotationOffset();
                                 UpdateDisplayedScaleOffset();
@@ -1517,11 +1526,11 @@ namespace NodesConstraints
                 newConstraint.fixDynamicBone = false;
 
                 if (positionLocks != null)
-                    newConstraint.positionLocks = positionLocks;
+                    newConstraint.positionLocks = positionLocks.Copy();
                 if (rotationLocks != null)
-                    newConstraint.rotationLocks = rotationLocks;
+                    newConstraint.rotationLocks = rotationLocks.Copy();
                 if (scaleLocks != null)
-                    newConstraint.scaleLocks = scaleLocks;
+                    newConstraint.scaleLocks = scaleLocks.Copy();
 
                 // Use current ParentTransform pos/rot/scale as default to not break backwards compatibility
                 // Update to after adding if needed (e.g. OnSceneLoad/OnSceneImport


### PR DESCRIPTION
**Change factors**
Multiply the movement/rotation/scale change of the parent by a factor and apply that movement to the child. Defaults to 1 to keep current behaviour.

e.g. with a movement factor of 2 on the position, the following would occur:
parent: (0, 0, 0) -> (3, 6, 0)
child: (0, 0, 0) -> (6, 12, 0)

**Movement dampening**
Dampens the childs movement towards the parent, making it follow the parent instead of a 1:1 position lock.
0 (or smaller) disables this and keeps current behaviour (and is the default).
The higher the number, the faster the child will follow the parent.

**Axis locking**
Only constrain the chosen axis to the parent. Letting the child move freely on the non-constrained axis.
The X/Y/Z labels are replaced by toggles styled as buttons, and are all turned on by default to keep current behaviour.

Added an extra row for every transform where I now put all the new functions

![image](https://github.com/IllusionMods/HSPlugins/assets/141709004/fb982975-0099-477e-bea1-69e511612b97)
