### PR TITLE
[NC] Add toggle for children resetting to original transform when contraint is disabled/removed

### DIFF
--- a/NodesConstraints.Core/NodesConstraints.cs
+++ b/NodesConstraints.Core/NodesConstraints.cs
@@ -764,7 +764,19 @@ namespace NodesConstraints
                                                 constraint.scale,
                                                 constraint.mirrorScale,
                                                 constraint.scaleOffset,
-                                                constraint.alias
+                                                constraint.alias,
+                                                constraint.positionChangeFactor,
+                                                constraint.rotationChangeFactor,
+                                                constraint.scaleChangeFactor,
+                                                constraint.positionDamp,
+                                                constraint.rotationDamp,
+                                                constraint.scaleDamp,
+                                                constraint.positionLocks,
+                                                constraint.rotationLocks,
+                                                constraint.scaleLocks,
+                                                constraint.resetOriginalPosition,
+                                                constraint.resetOriginalRotation,
+                                                constraint.resetOriginalScale
                                                );
 
                             if( newConstraint != null )


### PR DESCRIPTION
NC resets the child back to its original position when the constraint is disabled/removed. Got told this was actually something problematic for animators, and they have to use some weird constraint setup to go around this behaviour.

This toggle just allows you to disable the resetting on a per contraint basis. 

Also fixed the copying of contraints, since I seem to have forgotten in all previous PR's