### PR TITLE
[TL] Select the entire column when holding Left Alt

### DIFF
--- a/Timeline.Core/Timeline.cs
+++ b/Timeline.Core/Timeline.cs
@@ -2137,6 +2137,14 @@ namespace Timeline
                 Vector2 min = new Vector2(Mathf.Min(_areaSelectFirstPoint.x, localPoint.x), Mathf.Min(_areaSelectFirstPoint.y, localPoint.y));
                 Vector2 max = new Vector2(Mathf.Max(_areaSelectFirstPoint.x, localPoint.x), Mathf.Max(_areaSelectFirstPoint.y, localPoint.y));
 
+                if( Input.GetKey(KeyCode.LeftAlt) )
+                {
+                    //Maximize the top and bottom of the selection
+                    var rect = _keyframesContainer.rect;
+                    min.y = rect.yMin;
+                    max.y = rect.yMax;
+                }
+
                 _selectionArea.offsetMin = min;
                 _selectionArea.offsetMax = max;
             }
@@ -2166,6 +2174,14 @@ namespace Timeline
             }
             float minY = Mathf.Min(_areaSelectFirstPoint.y, localPoint.y);
             float maxY = Mathf.Max(_areaSelectFirstPoint.y, localPoint.y);
+
+            if (Input.GetKey(KeyCode.LeftAlt) )
+            {
+                //Maximize the top and bottom of the selection
+                var rect = _keyframesContainer.rect;
+                minY = rect.yMin;
+                maxY = rect.yMax;
+            }
 
             _selectionArea.gameObject.SetActive(false);
             _isAreaSelecting = false;


### PR DESCRIPTION
Added the ability to extend the timeline selection up and down by dragging while holding down the left Alt key.
Please merge if there is no problem.
As a matter of fact, I am unfamiliar with the timeline. Sorry if there is already some alternative function.

Normal drag:
![default](https://github.com/IllusionMods/HSPlugins/assets/4230203/c4e5b0c2-2c25-4fbc-bcf1-1350a32469a6)

Drag + LeftAlt:
Expands the vertical selection to the maximum.
![alt](https://github.com/IllusionMods/HSPlugins/assets/4230203/9545db42-6260-419f-8908-1509f609bd7c)

This PR was developed from a commission by Noctis17.