### PR TITLE
[NC] Disable the debugline when closing window through the close button

### DIFF
--- a/NodesConstraints.Core/NodesConstraints.cs
+++ b/NodesConstraints.Core/NodesConstraints.cs
@@ -1051,6 +1051,7 @@ namespace NodesConstraints
             if (GUI.Button(new Rect(_windowRect.width - visibleAreaSize - 2, 2, visibleAreaSize, visibleAreaSize), "X"))
             {
                 _showUI = false;
+                _selectedConstraint?.SetActiveDebugLines(false);
                 return;
             }
 


### PR DESCRIPTION
The debug lines would stay on screen if you closed the the NC window through the "X" button. This would not happen when using the shortcut again to close the window