### PR TITLE
[PE]Fixed behavior when holding XYZ scale button

### DIFF
--- a/Core.PoseEditor/AMModules/BonesEditor.cs
+++ b/Core.PoseEditor/AMModules/BonesEditor.cs
@@ -565,13 +565,13 @@ namespace HSPE.AMModules
                             boneTargetScale = Vector3.one;
                         }
 
-                        if (GUILayout.RepeatButton((-_scaleInc).ToString("+0.#####;-0.#####")) && _boneTarget != null)
+                        if (GUILayout.RepeatButton((-_scaleInc).ToString("+0.#####;-0.#####")) && RepeatControl() && _boneTarget != null)
                         {
                             shouldSaveValue = true;
                             boneTargetScale -= _scaleInc * Vector3.one;
                         }
 
-                        if (GUILayout.RepeatButton(_scaleInc.ToString("+0.#####;-0.#####")) && _boneTarget != null)
+                        if (GUILayout.RepeatButton(_scaleInc.ToString("+0.#####;-0.#####")) && RepeatControl() && _boneTarget != null)
                         {
                             shouldSaveValue = true;
                             boneTargetScale += _scaleInc * Vector3.one;


### PR DESCRIPTION
Only when you press and hold the XYZ button on Scale, there was no initial pooling, so I added it.