### PR TITLE
[PE] Fix Collider height being changed on its own just by selecting an item.

### DIFF
--- a/Core.PoseEditor/AMModules/CollidersEditor.cs
+++ b/Core.PoseEditor/AMModules/CollidersEditor.cs
@@ -1036,8 +1036,6 @@ namespace HSPE.AMModules
                 SetColliderRadius(collider, radius);
 
             float height = FloatEditor(collider.m_Height, 2 * collider.m_Radius, Mathf.Max(4f, 4f * collider.m_Radius), "Height\t");
-            if (height < collider.m_Radius * 2)
-                height = collider.m_Radius * 2;
             if (Mathf.Approximately(height, collider.m_Height) == false)
                 SetColliderHeight(collider, height);
 


### PR DESCRIPTION
As the title says.
This was an annoying behavior, so I'm removing the part that caused it.
Please merge if there is no problem!