### PR TITLE
[PE] Keep advanced mode enabled on object copy

### DIFF
--- a/Core.PoseEditor/HSPE.cs
+++ b/Core.PoseEditor/HSPE.cs
@@ -64,6 +64,7 @@ namespace HSPE
         internal static ConfigEntry<KeyboardShortcut> ConfigMainWindowShortcut { get; private set; }
         internal static ConfigEntry<bool> ConfigCrotchCorrectionByDefault { get; private set; }
         internal static ConfigEntry<bool> ConfigAnklesCorrectionByDefault { get; private set; }
+        internal static ConfigEntry<bool> ConfigKeepAdvancedModeEnabledOnCopy { get; private set; }
 
         internal static ConfigEntry<KeyboardShortcut> ConfigReorderFKBones { get; private set; }
 
@@ -76,6 +77,7 @@ namespace HSPE
             ConfigMainWindowShortcut = Config.Bind("Config", "Main Window Shortcut", new KeyboardShortcut(KeyCode.H));
             ConfigCrotchCorrectionByDefault = Config.Bind("Config", "Crotch Correction By Default", false);
             ConfigAnklesCorrectionByDefault = Config.Bind("Config", "AnklesCorrection By Default", false);
+            ConfigKeepAdvancedModeEnabledOnCopy = Config.Bind("Config", "Copy advanced mode enabled state on copy", false);
 
             ConfigReorderFKBones = Config.Bind(
                 "Config",

--- a/Core.PoseEditor/HSPE.cs
+++ b/Core.PoseEditor/HSPE.cs
@@ -64,7 +64,7 @@ namespace HSPE
         internal static ConfigEntry<KeyboardShortcut> ConfigMainWindowShortcut { get; private set; }
         internal static ConfigEntry<bool> ConfigCrotchCorrectionByDefault { get; private set; }
         internal static ConfigEntry<bool> ConfigAnklesCorrectionByDefault { get; private set; }
-        internal static ConfigEntry<bool> ConfigKeepAdvancedModeEnabledOnCopy { get; private set; }
+        internal static ConfigEntry<bool> ConfigDisableAdvancedModeOnCopy { get; private set; }
 
         internal static ConfigEntry<KeyboardShortcut> ConfigReorderFKBones { get; private set; }
 
@@ -77,7 +77,7 @@ namespace HSPE
             ConfigMainWindowShortcut = Config.Bind("Config", "Main Window Shortcut", new KeyboardShortcut(KeyCode.H));
             ConfigCrotchCorrectionByDefault = Config.Bind("Config", "Crotch Correction By Default", false);
             ConfigAnklesCorrectionByDefault = Config.Bind("Config", "AnklesCorrection By Default", false);
-            ConfigKeepAdvancedModeEnabledOnCopy = Config.Bind("Config", "Disable advanced mode on copied objects", true, "If disabled, advanced mode state is copied from the original studio object. If enabled, advanced mode is always disabled on the newly copied items.");
+            ConfigDisableAdvancedModeOnCopy = Config.Bind("Config", "Disable advanced mode on copied objects", true, "If disabled, advanced mode state is copied from the original studio object. If enabled, advanced mode is always disabled on the newly copied items.");
 
             ConfigReorderFKBones = Config.Bind(
                 "Config",

--- a/Core.PoseEditor/HSPE.cs
+++ b/Core.PoseEditor/HSPE.cs
@@ -77,7 +77,7 @@ namespace HSPE
             ConfigMainWindowShortcut = Config.Bind("Config", "Main Window Shortcut", new KeyboardShortcut(KeyCode.H));
             ConfigCrotchCorrectionByDefault = Config.Bind("Config", "Crotch Correction By Default", false);
             ConfigAnklesCorrectionByDefault = Config.Bind("Config", "AnklesCorrection By Default", false);
-            ConfigKeepAdvancedModeEnabledOnCopy = Config.Bind("Config", "Copy advanced mode enabled state on copy", false);
+            ConfigKeepAdvancedModeEnabledOnCopy = Config.Bind("Config", "Disable advanced mode on copied objects", true);
 
             ConfigReorderFKBones = Config.Bind(
                 "Config",

--- a/Core.PoseEditor/HSPE.cs
+++ b/Core.PoseEditor/HSPE.cs
@@ -77,7 +77,7 @@ namespace HSPE
             ConfigMainWindowShortcut = Config.Bind("Config", "Main Window Shortcut", new KeyboardShortcut(KeyCode.H));
             ConfigCrotchCorrectionByDefault = Config.Bind("Config", "Crotch Correction By Default", false);
             ConfigAnklesCorrectionByDefault = Config.Bind("Config", "AnklesCorrection By Default", false);
-            ConfigKeepAdvancedModeEnabledOnCopy = Config.Bind("Config", "Disable advanced mode on copied objects", true);
+            ConfigKeepAdvancedModeEnabledOnCopy = Config.Bind("Config", "Disable advanced mode on copied objects", true, "If disabled, advanced mode state is copied from the original studio object. If enabled, advanced mode is always disabled on the newly copied items.");
 
             ConfigReorderFKBones = Config.Bind(
                 "Config",

--- a/Core.PoseEditor/HSPE.cs
+++ b/Core.PoseEditor/HSPE.cs
@@ -77,7 +77,7 @@ namespace HSPE
             ConfigMainWindowShortcut = Config.Bind("Config", "Main Window Shortcut", new KeyboardShortcut(KeyCode.H));
             ConfigCrotchCorrectionByDefault = Config.Bind("Config", "Crotch Correction By Default", false);
             ConfigAnklesCorrectionByDefault = Config.Bind("Config", "AnklesCorrection By Default", false);
-            ConfigDisableAdvancedModeOnCopy = Config.Bind("Config", "Disable advanced mode on copied objects", true, "If disabled, advanced mode state is copied from the original studio object. If enabled, advanced mode is always disabled on the newly copied items.");
+            ConfigDisableAdvancedModeOnCopy = Config.Bind("Config", "Disable advanced mode on copied objects", false, "If disabled, advanced mode state is copied from the original studio object. If enabled, advanced mode is always disabled on the newly copied items.");
 
             ConfigReorderFKBones = Config.Bind(
                 "Config",

--- a/Core.PoseEditor/MainWindow.cs
+++ b/Core.PoseEditor/MainWindow.cs
@@ -1229,11 +1229,15 @@ namespace HSPE
         public void OnDuplicate(ObjectCtrlInfo source, ObjectCtrlInfo destination)
         {
             PoseController destinationController;
+            var sourceController = source.guideObject.transformTarget.gameObject.GetComponent<PoseController>();
             if (destination is OCIChar)
                 destinationController = destination.guideObject.transformTarget.gameObject.AddComponent<CharaPoseController>();
             else
+            {
                 destinationController = destination.guideObject.transformTarget.gameObject.AddComponent<PoseController>();
-            destinationController.LoadFrom(source.guideObject.transformTarget.gameObject.GetComponent<PoseController>());
+                destinationController.enabled = sourceController.enabled;
+            }
+            destinationController.LoadFrom(sourceController);
         }
         #endregion
 

--- a/Core.PoseEditor/MainWindow.cs
+++ b/Core.PoseEditor/MainWindow.cs
@@ -1235,7 +1235,9 @@ namespace HSPE
             else
             {
                 destinationController = destination.guideObject.transformTarget.gameObject.AddComponent<PoseController>();
-                destinationController.enabled = sourceController.enabled;
+                if (HSPE.ConfigKeepAdvancedModeEnabledOnCopy.Value)
+                    destinationController.enabled = sourceController.enabled;
+                else destinationController.enabled = false;
             }
             destinationController.LoadFrom(sourceController);
         }

--- a/Core.PoseEditor/MainWindow.cs
+++ b/Core.PoseEditor/MainWindow.cs
@@ -1235,7 +1235,7 @@ namespace HSPE
             else
             {
                 destinationController = destination.guideObject.transformTarget.gameObject.AddComponent<PoseController>();
-                if (HSPE.ConfigKeepAdvancedModeEnabledOnCopy.Value)
+                if (!HSPE.ConfigDisableAdvancedModeOnCopy.Value)
                     destinationController.enabled = sourceController.enabled;
                 else destinationController.enabled = false;
             }

--- a/Core.PoseEditor/PoseController.cs
+++ b/Core.PoseEditor/PoseController.cs
@@ -183,6 +183,7 @@ namespace HSPE
                 var parent = transform.parent?.GetComponentInParent<PoseController>();
                 parent?._childObjects.Add(gameObject);
             }
+            this.ExecuteDelayed2(() => { enabled = other.enabled; }, 3);
         }
 
         public void AdvancedModeWindow(int id)

--- a/Core.PoseEditor/PoseController.cs
+++ b/Core.PoseEditor/PoseController.cs
@@ -104,9 +104,9 @@ namespace HSPE
             else
             {
                 _currentModule = _bonesEditor;
-                // Disable by default on static studio items. Has to be done in here to handle studio "obj copy" button making a copy of this component
+                // Disable by default on static studio items
                 if (!(this is CharaPoseController))
-                    this.ExecuteDelayed2(() => { enabled = false; }, 2);
+                    this.enabled = false;
             }
 
             _currentModule.isEnabled = true;
@@ -183,7 +183,6 @@ namespace HSPE
                 var parent = transform.parent?.GetComponentInParent<PoseController>();
                 parent?._childObjects.Add(gameObject);
             }
-            this.ExecuteDelayed2(() => { enabled = other.enabled; }, 3);
         }
 
         public void AdvancedModeWindow(int id)


### PR DESCRIPTION
Advanced mode is disabled by default on all items, and is disabled using `this.ExecuteDelayed2(() => { enabled = other.enabled; }, 2);`  in the `Awake` function.

This just syncs the controller enabled state with the source controller when it's copied