### PR TITLE
[TL] Fixed keyframes sharing the same AnimationCurve.

### DIFF
--- a/Timeline.Core/Timeline.cs
+++ b/Timeline.Core/Timeline.cs
@@ -2802,7 +2802,7 @@ namespace Timeline
                 Keyframe keyframe;
                 KeyValuePair<float, Keyframe> pair = interpolable.keyframes.LastOrDefault(k => k.Key < time);
                 if (pair.Value != null)
-                    keyframe = new Keyframe(interpolable.GetValue(), interpolable, pair.Value.curve);
+                    keyframe = new Keyframe(interpolable.GetValue(), interpolable, new AnimationCurve(pair.Value.curve.keys));
                 else
                     keyframe = new Keyframe(interpolable.GetValue(), interpolable, AnimationCurve.Linear(0f, 0f, 1f, 1f));
                 interpolable.keyframes.Add(time, keyframe);


### PR DESCRIPTION
Fixed a bug where all new keyframes shared the same **AnimationCurve** as the last keyframe of the **interpolable**.

This bug was the one mentioned by **YuukiS** in the discord server.