### PR TITLE
[VE] Fix the issue where some pixels of the previous frame are exposed when exporting video in Win32 mode

### DIFF
--- a/VideoExport.Core/ScreenshotPlugins/Bitmap.cs
+++ b/VideoExport.Core/ScreenshotPlugins/Bitmap.cs
@@ -367,6 +367,7 @@ namespace VideoExport.ScreenshotPlugins
             if (height % 2 != 0)
                 height += 1;
 
+            this._graphics.Clear(System.Drawing.Color.Black);
             this._graphics.CopyFromScreen(rect.left, rect.top, 0, 0, new Size(width, height), CopyPixelOperation.SourceCopy);
 
             switch (this._imageFormat)


### PR DESCRIPTION
The black pixels in the current frame may become transparent due to the alpha channel of 0, possibly caused by NaN values in calculations, which can lead to exposure of the previous frame in the current one. Therefore, we always begin by clearing the graphics black.

