### PR TITLE
[PE] Collider and BlendShapes modules enhancements.

### DIFF
--- a/Core.PoseEditor/AMModules/BoobsEditor.cs
+++ b/Core.PoseEditor/AMModules/BoobsEditor.cs
@@ -323,6 +323,9 @@ namespace HSPE.AMModules
                     {
                         if (bone.Colliders.Contains(normalCollider) == false)
                             bone.Colliders.Add(normalCollider);
+
+                        if (pair.Value._addNewDynamicBonesAsDefault == false)
+                            pair.Value.SetIgnoreDynamicBone(normalCollider, _parent, bone, true);
                     }
                 }
             }

--- a/Core.PoseEditor/AMModules/CollidersEditor.cs
+++ b/Core.PoseEditor/AMModules/CollidersEditor.cs
@@ -447,6 +447,7 @@ namespace HSPE.AMModules
 #endif
         internal readonly Dictionary<DynamicBoneColliderBase, ColliderDataBase> _dirtyColliders = new Dictionary<DynamicBoneColliderBase, ColliderDataBase>();
         private Vector2 _ignoredDynamicBonesScroll;
+        private string _ignoredDynamicBonesFilter = "";
         #endregion
 
         #region Public Variables
@@ -665,16 +666,23 @@ namespace HSPE.AMModules
                 GUILayout.BeginVertical(GUI.skin.box);
                 GUILayout.BeginHorizontal();
                 GUILayout.Label("Affected Dynamic Bones", GUILayout.ExpandWidth(false));
+                GUILayout.FlexibleSpace();
 
                 _addNewDynamicBonesAsDefault = GUILayout.Toggle(_addNewDynamicBonesAsDefault, "Enable New Dynamic Bones", GUILayout.ExpandWidth(false));
 
-                GUILayout.FlexibleSpace();
                 if (GUILayout.Button("All off", GUILayout.ExpandWidth(false)))
                     SetIgnoreAllDynamicBones(_colliderTarget, true);
                 if (GUILayout.Button("All on", GUILayout.ExpandWidth(false)))
                     SetIgnoreAllDynamicBones(_colliderTarget, false);
                 GUILayout.EndHorizontal();
                 {
+                    GUILayout.BeginHorizontal();
+                    GUILayout.Label("Search : ", GUILayout.ExpandWidth(false));
+                    _ignoredDynamicBonesFilter = GUILayout.TextField(_ignoredDynamicBonesFilter);
+                    if (GUILayout.Button("X", GUILayout.ExpandWidth(false)))
+                        _ignoredDynamicBonesFilter = "";
+                    GUILayout.EndHorizontal();
+
                     ColliderDataBase cd;
                     if (_dirtyColliders.TryGetValue(_colliderTarget, out cd) == false)
                         cd = null;
@@ -682,13 +690,13 @@ namespace HSPE.AMModules
                     _ignoredDynamicBonesScroll = GUILayout.BeginScrollView(_ignoredDynamicBonesScroll);
                     foreach (PoseController controller in PoseController._poseControllers)
                     {
-                        int total = controller._dynamicBonesEditor._dynamicBones.Count;
+                        int total = controller._dynamicBonesEditor._dynamicBones.Where(d => d != null && d.m_Root != null && d.m_Root.name.IndexOf(_ignoredDynamicBonesFilter, StringComparison.OrdinalIgnoreCase) != -1).Count();
                         CharaPoseController charaPoseController = null;
                         if (CharaPoseController._charaPoseControllers.Contains(controller))
                         {
                             charaPoseController = (CharaPoseController)controller;
                             if (charaPoseController._boobsEditor != null)
-                                total += charaPoseController._boobsEditor._dynamicBones.Length;
+                                total += charaPoseController._boobsEditor._dynamicBones.Where(d => d != null && d.Root != null && d.Root.name.IndexOf(_ignoredDynamicBonesFilter, StringComparison.OrdinalIgnoreCase) != -1).Count();
                         }
                         if (total == 0)
                             continue;
@@ -705,7 +713,7 @@ namespace HSPE.AMModules
                         GUILayout.BeginHorizontal();
                         foreach (DynamicBone dynamicBone in controller._dynamicBonesEditor._dynamicBones)
                         {
-                            if (dynamicBone.m_Root == null)
+                            if (dynamicBone == null || dynamicBone.m_Root == null || dynamicBone.m_Root.name.IndexOf(_ignoredDynamicBonesFilter, StringComparison.OrdinalIgnoreCase) == -1)
                                 continue;
                             bool e = ignored == null || ignored.Contains(dynamicBone) == false;
                             bool newE = GUILayout.Toggle(e, dynamicBone.m_Root.name);
@@ -729,6 +737,8 @@ namespace HSPE.AMModules
                         {
                             foreach (DynamicBone_Ver02 dynamicBone in charaPoseController._boobsEditor._dynamicBones)
                             {
+                                if (dynamicBone == null || dynamicBone.Root == null || dynamicBone.Root.name.IndexOf(_ignoredDynamicBonesFilter, StringComparison.OrdinalIgnoreCase) == -1)
+                                    continue;
                                 bool e = ignored == null || ignored.Contains(dynamicBone) == false;
                                 bool newE = GUILayout.Toggle(e, dynamicBone.Root.name);
                                 if (e != newE)

--- a/Core.PoseEditor/AMModules/CollidersEditor.cs
+++ b/Core.PoseEditor/AMModules/CollidersEditor.cs
@@ -700,15 +700,53 @@ namespace HSPE.AMModules
                         }
                         if (total == 0)
                             continue;
+
+                        if (cd == null || cd.ignoredDynamicBones.TryGetValue(controller, out HashSet<object> ignored) == false)
+                            ignored = null;
+
+                        GUILayout.BeginVertical(GUI.skin.box);
                         GUILayout.BeginHorizontal();
                         GUILayout.Label(controller.target.oci.treeNodeObject.textName + " (" + controller.target.oci.guideObject.transformTarget.name + ") ", GUILayout.ExpandWidth(false));
                         if (GUILayout.Button("Center camera on", GUILayout.ExpandWidth(false)))
                             Studio.Studio.Instance.cameraCtrl.targetPos = controller.target.oci.guideObject.transformTarget.position;
+                        if (GUILayout.Button("All off", GUILayout.ExpandWidth(false)))
+                        {
+                            foreach (DynamicBone dynamicBone in controller._dynamicBonesEditor._dynamicBones)
+                                SetIgnoreDynamicBone(_colliderTarget, controller, dynamicBone, true);
+
+                            if (
+#if AISHOUJO || HONEYSELECT2
+                                this._isTargetNormalCollider && 
+#endif
+                                charaPoseController != null &&
+                                charaPoseController._boobsEditor != null
+                                )
+                            {
+                                foreach (DynamicBone_Ver02 dynamicBone in charaPoseController._boobsEditor._dynamicBones)
+                                    SetIgnoreDynamicBone(_colliderTarget, controller, dynamicBone, true);
+
+                            }
+                        }
+                        if (GUILayout.Button("All on", GUILayout.ExpandWidth(false)))
+                        {
+                            foreach (DynamicBone dynamicBone in controller._dynamicBonesEditor._dynamicBones)
+                                SetIgnoreDynamicBone(_colliderTarget, controller, dynamicBone, false);
+
+                            if (
+#if AISHOUJO || HONEYSELECT2
+                                this._isTargetNormalCollider && 
+#endif
+                                charaPoseController != null &&
+                                charaPoseController._boobsEditor != null
+                                )
+                            {
+                                foreach (DynamicBone_Ver02 dynamicBone in charaPoseController._boobsEditor._dynamicBones)
+                                    SetIgnoreDynamicBone(_colliderTarget, controller, dynamicBone, false);
+
+                            }
+                        }
                         GUILayout.EndHorizontal();
 
-                        HashSet<object> ignored;
-                        if (cd == null || cd.ignoredDynamicBones.TryGetValue(controller, out ignored) == false)
-                            ignored = null;
                         int i = 1;
                         GUILayout.BeginHorizontal();
                         foreach (DynamicBone dynamicBone in controller._dynamicBonesEditor._dynamicBones)
@@ -752,6 +790,7 @@ namespace HSPE.AMModules
                             }
                         }
                         GUILayout.EndHorizontal();
+                        GUILayout.EndVertical();
                     }
                     GUILayout.EndScrollView();
                 }

--- a/Core.PoseEditor/AMModules/CollidersEditor.cs
+++ b/Core.PoseEditor/AMModules/CollidersEditor.cs
@@ -449,6 +449,11 @@ namespace HSPE.AMModules
         private Vector2 _ignoredDynamicBonesScroll;
         #endregion
 
+        #region Public Variables
+        public bool _addNewDynamicBonesAsDefault = true;
+        public bool _addNewDynamicBonesAsDefaultSaved = true;
+        #endregion
+
         #region Public Accessors
         public override AdvancedModeModuleType type { get { return AdvancedModeModuleType.CollidersEditor; } }
         public override string displayName { get { return "Colliders"; } }
@@ -660,6 +665,9 @@ namespace HSPE.AMModules
                 GUILayout.BeginVertical(GUI.skin.box);
                 GUILayout.BeginHorizontal();
                 GUILayout.Label("Affected Dynamic Bones", GUILayout.ExpandWidth(false));
+
+                _addNewDynamicBonesAsDefault = GUILayout.Toggle(_addNewDynamicBonesAsDefault, "Enable New Dynamic Bones", GUILayout.ExpandWidth(false));
+
                 GUILayout.FlexibleSpace();
                 if (GUILayout.Button("All off", GUILayout.ExpandWidth(false)))
                     SetIgnoreAllDynamicBones(_colliderTarget, true);
@@ -869,6 +877,9 @@ namespace HSPE.AMModules
                 }
                 xmlWriter.WriteEndElement();
             }
+            xmlWriter.WriteStartElement("collidersEditor");
+            xmlWriter.WriteAttributeString("addNewDynamicBonesAsDefault", XmlConvert.ToString(_addNewDynamicBonesAsDefault));
+            xmlWriter.WriteEndElement();
             return written;
         }
 
@@ -982,6 +993,11 @@ namespace HSPE.AMModules
                         HSPE.Logger.LogError("Couldn't load collider for object " + _parent.name + " " + node.OuterXml + "\n" + e);
                     }
                 }
+            }
+            XmlNode collidersEdtior = xmlNode.FindChildNode("collidersEditor");
+            if (collidersEdtior != null)
+            {
+                _addNewDynamicBonesAsDefaultSaved = collidersEdtior.Attributes["addNewDynamicBonesAsDefault"] == null || XmlConvert.ToBoolean(collidersEdtior.Attributes["addNewDynamicBonesAsDefault"].Value);
             }
             return changed;
         }
@@ -1126,7 +1142,7 @@ namespace HSPE.AMModules
             }
         }
 
-        private void SetIgnoreDynamicBone(DynamicBoneColliderBase collider, PoseController dynamicBoneParent, object dynamicBone, bool ignore)
+        public void SetIgnoreDynamicBone(DynamicBoneColliderBase collider, PoseController dynamicBoneParent, object dynamicBone, bool ignore)
         {
             ColliderDataBase colliderData = SetColliderDirty(collider);
             DynamicBoneCollider normalCollider = collider as DynamicBoneCollider;

--- a/Core.PoseEditor/AMModules/DynamicBonesEditor.cs
+++ b/Core.PoseEditor/AMModules/DynamicBonesEditor.cs
@@ -1582,6 +1582,9 @@ namespace HSPE.AMModules
                             bone.m_Colliders.Add(pair.Key);
                             NotifyDynamicBoneForUpdate(bone);
                         }
+
+                        if (pair.Value._addNewDynamicBonesAsDefault == false)
+                            pair.Value.SetIgnoreDynamicBone(pair.Key, _parent, bone, true);
                     }
                 }
             }

--- a/Core.PoseEditor/MainWindow.cs
+++ b/Core.PoseEditor/MainWindow.cs
@@ -1731,6 +1731,8 @@ namespace HSPE
             controller.ScheduleLoad(node, e =>
             {
                 controller.enabled = controllerEnabled;
+                if (controller._collidersEditor != null) //applying here the saved value so that it is only loaded after the loading/importing of an scene is finished!
+                    controller._collidersEditor._addNewDynamicBonesAsDefault = controller._collidersEditor._addNewDynamicBonesAsDefaultSaved;
             });
 
         }
@@ -1746,6 +1748,8 @@ namespace HSPE
             controller.ScheduleLoad(node, e =>
             {
                 controller.enabled = controllerEnabled;
+                if (controller._collidersEditor != null) //applying here the saved value so that it is only loaded after the loading/importing of an scene is finished!
+                    controller._collidersEditor._addNewDynamicBonesAsDefault = controller._collidersEditor._addNewDynamicBonesAsDefaultSaved;
             });
 
         }


### PR DESCRIPTION
- Added a toggle in the **Colliders window** that controls whether newly registered DynamicBones should start enabled or disabled. 
- Added 'All on' and 'All of' buttons for each individual object in the **Colliders window**.
- Added a search bar in the **Colliders window**.
- Added a 'Link BlendShapes with same name' toggle option in the **BlendShapes window** and its Timeline Interpolable.

This closes #18 and closes #85 

### Enable New Dynamic Bones toggle:
https://github.com/user-attachments/assets/968e5662-3f3d-43d8-aff9-4d3b8fd2b71b
### Link same name toggle:
https://github.com/user-attachments/assets/cf819553-9b81-4c9f-a151-25cd8f930931
