### PR TITLE
[PE]BlendshapeEditor - Fix memory waste

### DIFF
--- a/Core.PoseEditor/AMModules/BlendShapesEditor.cs
+++ b/Core.PoseEditor/AMModules/BlendShapesEditor.cs
@@ -1544,7 +1544,7 @@ namespace HSPE.AMModules
         {
             foreach (var currBlendRenderer in _blendRenderers)
             {
-                if (currBlendRenderer.Value._dirtyBlends.Count != currBlendRenderer.Value._renderer.sharedMesh.blendShapeCount)
+                if (currBlendRenderer.Value._blendIndics.Count != currBlendRenderer.Value._renderer.sharedMesh.blendShapeCount)
                 {
                     currBlendRenderer.Value._blendIndics.Clear();
                     currBlendRenderer.Value._blendNames.Clear();


### PR DESCRIPTION
The conditions for updating _blendIndics were not appropriate, resulting in a terrible waste of memory.
I don't have the full specs of the revamped PE, but this is probably the way it was originally intended to work.