### PR TITLE
[NC] Allow main camera as parent

### DIFF
--- a/NodesConstraints.Core/NodesConstraints.cs
+++ b/NodesConstraints.Core/NodesConstraints.cs
@@ -60,6 +60,7 @@ namespace NodesConstraints
         private const float _circleRadius = 0.1f;
 #endif
 
+        private const int MainCameraParenObjectIndex = -2;
         private static NodesConstraints _self;
 
 #if IPA
@@ -1803,7 +1804,7 @@ namespace NodesConstraints
                     continue;
 
                 Transform parentTransform;
-                if (parentObjectIndex == -2)
+                if (parentObjectIndex == MainCameraParenObjectIndex)
                     parentTransform = Studio.Studio.Instance.cameraCtrl.mainCmaera.transform;
                 else
                 {
@@ -2074,7 +2075,7 @@ namespace NodesConstraints
                 int parentObjectIndex = -1;
                 Transform parentT = constraint.parentTransform;
                 if (parentT == Studio.Studio.Instance.cameraCtrl.mainCmaera.transform)
-                    parentObjectIndex = -2;
+                    parentObjectIndex = MainCameraParenObjectIndex;
                 else
                     while ((parentObjectIndex = dic.FindIndex(e => e.Value.guideObject.transformTarget == parentT)) == -1)
                         parentT = parentT.parent;

--- a/NodesConstraints.Core/NodesConstraints.cs
+++ b/NodesConstraints.Core/NodesConstraints.cs
@@ -1348,10 +1348,12 @@ namespace NodesConstraints
                 }
 
                 GUILayout.BeginHorizontal();
-                GUI.enabled = _selectedBone != null;
-                if (GUILayout.Button("Set as parent"))
+                if (GUILayout.Button(selectedGuideObject != null ? "Set as parent" : "Set as parent (Camera)"))
                 {
-                    _displayedConstraint.parentTransform = _advancedList ? _selectedBone : selectedGuideObject.transformTarget;
+                    if (selectedGuideObject != null)
+                        _displayedConstraint.parentTransform = _advancedList ? _selectedBone : selectedGuideObject.transformTarget;
+                    else
+                        _displayedConstraint.parentTransform = Studio.Studio.Instance.cameraCtrl.mainCmaera.transform;
                 }
                 GUI.enabled = true;
 
@@ -1799,8 +1801,15 @@ namespace NodesConstraints
                 int parentObjectIndex = XmlConvert.ToInt32(childNode.Attributes["parentObjectIndex"].Value);
                 if (parentObjectIndex >= dic.Count)
                     continue;
-                Transform parentTransform = dic[parentObjectIndex].Value.guideObject.transformTarget;
-                parentTransform = parentTransform.Find(childNode.Attributes["parentPath"].Value);
+
+                Transform parentTransform;
+                if (parentObjectIndex == -2)
+                    parentTransform = Studio.Studio.Instance.cameraCtrl.mainCmaera.transform;
+                else
+                {
+                    parentTransform = dic[parentObjectIndex].Value.guideObject.transformTarget;
+                    parentTransform = parentTransform.Find(childNode.Attributes["parentPath"].Value);
+                }
                 if (parentTransform == null)
                     continue;
 
@@ -2064,8 +2073,11 @@ namespace NodesConstraints
                 Constraint constraint = _constraints[i];
                 int parentObjectIndex = -1;
                 Transform parentT = constraint.parentTransform;
-                while ((parentObjectIndex = dic.FindIndex(e => e.Value.guideObject.transformTarget == parentT)) == -1)
-                    parentT = parentT.parent;
+                if (parentT == Studio.Studio.Instance.cameraCtrl.mainCmaera.transform)
+                    parentObjectIndex = -2;
+                else
+                    while ((parentObjectIndex = dic.FindIndex(e => e.Value.guideObject.transformTarget == parentT)) == -1)
+                        parentT = parentT.parent;
                 string parentPath = constraint.parentTransform.GetPathFrom(parentT);
 
                 int childObjectIndex = -1;


### PR DESCRIPTION
Allows you to set the main camera as the parent in a constraint. By having nothing selected the parent button will target the main camera transform.

Mostly useful to make something like a D-modlight always point the same way the camera is looking, or to let an item always face the camera.
This also keeps working when switching to camera objects.

Internally I used -2 as the parent index to indicate it should use the camera instead for saving and loading (-1 is left as the default for when there is no index).

It doesn't have a _ton_ of use, especially since items can get kind of jittery when bound to the camera. But stuff like linking the D-Modmap don't really have a visible jitter