### PR TITLE
[TL]Fix CurrentTime calculation

### DIFF
--- a/Timeline.Core/Timeline.cs
+++ b/Timeline.Core/Timeline.cs
@@ -3183,14 +3183,14 @@ namespace Timeline
 
         private void UseCurrentTime()
         {
-            float currentTime = _playbackTime % _duration;
+            float currentTime = _playbackTime;
             SaveKeyframeTime(currentTime);
             UpdateKeyframeTimeTextField();
         }
 
         private void DragAtCurrentTime()
         {
-            float currentTime = _playbackTime % _duration;
+            float currentTime = _playbackTime;
             float min = _selectedKeyframes.Min(k => k.Key);
 
             // Checking if all keyframes can be moved.

--- a/Timeline.Core/Timeline.cs
+++ b/Timeline.Core/Timeline.cs
@@ -3183,14 +3183,18 @@ namespace Timeline
 
         private void UseCurrentTime()
         {
-            float currentTime = _playbackTime;
+            float currentTime = _playbackTime % _duration;
+            if (currentTime == 0f && _playbackTime == _duration)
+                currentTime = _duration;
             SaveKeyframeTime(currentTime);
             UpdateKeyframeTimeTextField();
         }
 
         private void DragAtCurrentTime()
         {
-            float currentTime = _playbackTime;
+            float currentTime = _playbackTime % _duration;
+            if (currentTime == 0f && _playbackTime == _duration)
+                currentTime = _duration;
             float min = _selectedKeyframes.Min(k => k.Key);
 
             // Checking if all keyframes can be moved.


### PR DESCRIPTION
When doing UseCurrentTime or DragAtCurrentTime, keyframes could not be moved to the last time.
I don't think there is any particular advantage to looping within _duration.