### PR TITLE
[VE] Additional MP4 codecs and MOV extension

### DIFF
--- a/VideoExport.Core/Extensions/IExtension.cs
+++ b/VideoExport.Core/Extensions/IExtension.cs
@@ -27,7 +27,8 @@ namespace VideoExport.Extensions
         MP4,
         WEBM,
         GIF,
-        AVI
+        AVI,
+        MOV
     }
 
 }

--- a/VideoExport.Core/Extensions/MOVExtension.cs
+++ b/VideoExport.Core/Extensions/MOVExtension.cs
@@ -1,0 +1,71 @@
+﻿using UnityEngine;
+using VideoExport.ScreenshotPlugins;
+
+namespace VideoExport.Extensions
+{
+    public class MOVExtension : AFFMPEGBasedExtension
+    {
+        private enum Codec
+        {
+            ProRes4444
+        }
+
+        private readonly string[] _codecNames = { "Apple ProRes 4444" };
+        private readonly string[] _codecCLIOptions = { "prores_ks" };
+
+        private Codec _codec;
+
+        public MOVExtension() : base()
+        {
+            this._codec = (Codec)VideoExport._configFile.AddInt("movCodec", (int)Codec.ProRes4444, true);
+        }
+
+        public override string GetArguments(string framesFolder, string prefix, string postfix, string inputExtension, byte bitDepth, int fps, bool transparency, bool resize, int resizeX, int resizeY, string fileName)
+        {
+            this._progress = 1;
+            int coreCount = _coreCount;
+            string pixFmt = transparency ? "yuva444p10le" : "yuv444p10le";
+
+            string videoFilterArgument = this.CompileFilters(resize, resizeX, resizeY);
+
+            string codec = _codecCLIOptions[(int)this._codec];
+            string codecExtraArgs = "-profile 4 -alpha_bits 8 -bits_per_mb 250 -mbs_per_slice 4";
+
+            string ffmpegArgs = $"-loglevel error -r {fps} -f image2 -threads {coreCount} -progress pipe:1";
+            string inputArgs = $"-i \"{framesFolder}\\{prefix}%d{postfix}.{inputExtension}\" -pix_fmt {pixFmt} {videoFilterArgument}";
+            string codecArgs = $"-c:v {codec} {codecExtraArgs}";
+            string outputArgs = $"\"{fileName}.mov\"";
+
+            return $"{ffmpegArgs} {inputArgs} {codecArgs} {outputArgs}";
+        }
+
+        public override bool IsCompatibleWithPlugin(IScreenshotPlugin plugin, out string reason)
+        {
+            reason = null;
+            return true;
+        }
+
+        public override void DisplayParams()
+        {
+            GUILayout.BeginHorizontal();
+            {
+                GUILayout.Label(VideoExport._currentDictionary.GetString(VideoExport.TranslationKey.MOVCodec), GUILayout.ExpandWidth(false));
+                this._codec = (Codec)GUILayout.SelectionGrid((int)this._codec, this._codecNames, this._codecNames.Length);
+            }
+            GUILayout.EndHorizontal();
+
+            Color c = GUI.color;
+            GUI.color = Color.yellow;
+            GUILayout.Label(VideoExport._currentDictionary.GetString(VideoExport.TranslationKey.MOVProResWarning));
+            GUI.color = c;
+
+            base.DisplayParams();
+        }
+
+        public override void SaveParams()
+        {
+            VideoExport._configFile.SetInt("movCodec", (int)this._codec);
+            base.SaveParams();
+        }
+    }
+}

--- a/VideoExport.Core/Resources/English.xml
+++ b/VideoExport.Core/Resources/English.xml
@@ -66,6 +66,8 @@
   <string key="GIFError" value="GIF is only compatible with PNG images." />
   <string key="MP4Codec" value="Codec" />
   <string key="H265Warning" value="The H.265 codec will give you smaller file sizes for the same visual quality as H.264 but it will not embed correctly in most browsers/Discord." />
+  <string key="HwAccelCodec" value="Use GPU-accelerated codec" />
+  <string key="HwAccelWarning" value="The GPU-accelerated codec produces larger file sizes." />
   <string key="MP4Quality" value="Quality (lower is better but 18 is visually lossless)" />
   <string key="MP4Preset" value="Encoding Preset (slower = better quality/filesize, &quot;Medium&quot; is a good compromise)" />
   <string key="MP4PresetVerySlow" value="Very Slow" />

--- a/VideoExport.Core/Resources/English.xml
+++ b/VideoExport.Core/Resources/English.xml
@@ -87,4 +87,6 @@
   <string key="WEBMDeadlineBest" value="Best" />
   <string key="WEBMDeadlineGood" value="Good" />
   <string key="WEBMDeadlineRealtime" value="Realtime" />
+  <string key="MOVCodec" value="Codec" />
+  <string key="MOVProResWarning" value="Produces very large files meant for video editing." />
 </root>

--- a/VideoExport.Core/Resources/中文.xml
+++ b/VideoExport.Core/Resources/中文.xml
@@ -87,4 +87,6 @@
   <string key="WEBMDeadlineBest" value="最好" />
   <string key="WEBMDeadlineGood" value="中等" />
   <string key="WEBMDeadlineRealtime" value="实时" />
+  <string key="MOVCodec" value="编码器" />
+  <string key="MOVProResWarning" value="生成用于视频编辑的非常大的文件。" />
 </root>

--- a/VideoExport.Core/Resources/中文.xml
+++ b/VideoExport.Core/Resources/中文.xml
@@ -66,6 +66,8 @@
   <string key="MP4Codec" value="编码器" />
   <string key="H265Warning" value="主流的视频编码器: H.265 拥有更好的压缩比，与H.264视频质量无异，但无法支持浏览器WEB前端嵌入使用
           如果你需要使用浏览器播放此视频，建议不要使用此编码" />
+  <string key="HwAccelCodec" value="使用 GPU 加速编解码器" />
+  <string key="HwAccelWarning" value="GPU 加速编解码器可产生更大的文件大小。" />
   <string key="MP4Quality" value="视频质量 ( 越低越好，当参数值为18的时候，视觉上与无损无异 )" />
   <string key="MP4Preset" value="编码方案 ( 较慢: 更高的视频质量/更理想的文件大小，中: 折中方案 )" />
   <string key="MP4PresetVerySlow" value="最慢" />

--- a/VideoExport.Core/VideoExport.Core.projitems
+++ b/VideoExport.Core/VideoExport.Core.projitems
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\AVIExtension.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\GIFExtension.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\IExtension.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensions\MOVExtension.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\MP4Extension.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\WEBMExtension.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ParallelScreenshotEncoder.cs" />

--- a/VideoExport.Core/VideoExport.cs
+++ b/VideoExport.Core/VideoExport.cs
@@ -167,6 +167,8 @@ namespace VideoExport
             WEBMDeadlineBest,
             WEBMDeadlineGood,
             WEBMDeadlineRealtime,
+            MOVCodec,
+            MOVProResWarning,
         }
 
         private enum LimitDurationType
@@ -303,6 +305,7 @@ namespace VideoExport
             _extensions.Add(new WEBMExtension());
             _extensions.Add(new GIFExtension());
             _extensions.Add(new AVIExtension());
+            _extensions.Add(new MOVExtension());
 
             _extensionsNames = Enum.GetNames(typeof(ExtensionsType));
 
@@ -798,7 +801,7 @@ namespace VideoExport
 
                 GUILayout.BeginHorizontal();
                 GUILayout.FlexibleSpace();
-                GUILayout.Box("", _customBoxStyle, GUILayout.Width((_windowRect.width - 20) * _progressBarPercentage), GUILayout.Height(10));
+                GUILayout.Box("", _customBoxStyle, GUILayout.Width((_windowRect.width - 20) * Mathf.Clamp(_progressBarPercentage, 0f, 1f)), GUILayout.Height(10));
                 GUILayout.FlexibleSpace();
                 GUILayout.EndHorizontal();
 

--- a/VideoExport.Core/VideoExport.cs
+++ b/VideoExport.Core/VideoExport.cs
@@ -146,6 +146,8 @@ namespace VideoExport
             GIFError,
             MP4Codec,
             H265Warning,
+            HwAccelCodec,
+            HwAccelWarning,
             MP4Quality,
             MP4Preset,
             MP4PresetVerySlow,


### PR DESCRIPTION
Adds a toggle under the MP4 to use GPU-accelerated codecs. It's a large increase in encoding speed at the cost of compression efficiency. In my case 5x faster encoding and 2-3x larger output file (12600KF -> 3060ti).

Adds the MOV extension and Apple ProRes 4444 codec for it.