### PR TITLE
[NC] Fix NC being dependent on a character being in the scene

### DIFF
--- a/NodesConstraints.Core/NodesConstraints.cs
+++ b/NodesConstraints.Core/NodesConstraints.cs
@@ -532,7 +532,10 @@ namespace NodesConstraints
             _dispatcher = Camera.main.gameObject.AddComponent<CameraEventsDispatcher>();
             VectorLine.SetCamera3D(Camera.main);
             if (Camera.main.GetComponent<Expression>() == null)
+            {
+                // We need an Expression to call Expression_LateUpdate Postfix when no characters are in the scene
                 Camera.main.gameObject.AddComponent<Expression>();
+            }
 #if KOIKATSU
             _kkAnimationControllerInstalled = BepInEx.Bootstrap.Chainloader.Plugins
                                                           .Select(MetadataHelper.GetMetadata)
@@ -562,6 +565,8 @@ namespace NodesConstraints
             if (_studioLoaded == false)
                 return;
             _totalActiveExpressions = _allExpressions.Count(e => e.enabled && e.gameObject.activeInHierarchy);
+            if (Camera.main.GetComponent<Expression>() != null)
+                _totalActiveExpressions += 1; // Expression is added to MainCamera in Init()
             _currentExpressionIndex = 0;
             if (ConfigMainWindowShortcut.Value.IsDown())
             {


### PR DESCRIPTION
Fixes an issue where NC does not update when a character isn't in the scene:

https://github.com/user-attachments/assets/45a3053d-5993-4966-a9fd-4e7a0f652796

This happens because the postfix looks ahead in an attempt to find the last LateUpdate call, but `_totalActiveExpressions = 0`:
https://github.com/IllusionMods/HSPlugins/blob/35d1deb454717f78a5a20ba636609fa597e24730/NodesConstraints.Core/NodesConstraints.cs#L686-L695

The reason this is called in the first place is because an `Expression` component is added to the `MainCamera` in `Init()` to address this dependency on a character. This dummy expression is excluded by the Count filter, causing `_totalActiveExpression` to be off by one.