### PR TITLE
[VE] Add JPG encoding in ScreenshotManager (KK) and Builtin

### DIFF
--- a/VideoExport.Core/ScreenshotPlugins/Builtin.cs
+++ b/VideoExport.Core/ScreenshotPlugins/Builtin.cs
@@ -49,6 +49,8 @@ namespace VideoExport.ScreenshotPlugins
                         return "bmp";
                     case VideoExport.ImgFormat.PNG:
                         return "png";
+                    case VideoExport.ImgFormat.JPG:
+                        return "jpg";
 #if !HONEYSELECT
                     case VideoExport.ImgFormat.EXR:
                         return "exr";

--- a/VideoExport.Core/ScreenshotPlugins/ScreencapPlugin.cs
+++ b/VideoExport.Core/ScreenshotPlugins/ScreencapPlugin.cs
@@ -48,7 +48,7 @@ namespace VideoExport.ScreenshotPlugins
                 return Vector2.zero;
             }
         }
-        public VideoExport.ImgFormat imageFormat { get { return VideoExport.ImgFormat.PNG; } }
+        public VideoExport.ImgFormat imageFormat { get { return this._useJpg.Value ? VideoExport.ImgFormat.JPG : VideoExport.ImgFormat.PNG; } }
 
         public bool transparency { get { return this._captureAlpha.Value; } }
         public string extension { get { return this._useJpg.Value ? "jpg" : "png"; } }

--- a/VideoExport.Core/TextureEncoder.cs
+++ b/VideoExport.Core/TextureEncoder.cs
@@ -27,6 +27,9 @@ namespace VideoExport.Core
                 case VideoExport.ImgFormat.PNG:
                     bytes = texture.EncodeToPNG();
                     break;
+                case VideoExport.ImgFormat.JPG:
+                    bytes = texture.EncodeToJPG();
+                    break;
                 case VideoExport.ImgFormat.EXR:
                     bytes = texture.EncodeToEXR();
                     break;

--- a/VideoExport.Core/VideoExport.cs
+++ b/VideoExport.Core/VideoExport.cs
@@ -66,6 +66,7 @@ namespace VideoExport
         {
             BMP,
             PNG,
+            JPG,
 #if !HONEYSELECT //Someday I hope...
             EXR
 #endif


### PR DESCRIPTION
This PR adds JPG encoding to the Builtin screenshot tool and fixes the following issue:
- When ScreenshotManager is set to JPG, VE exports a .png encoded image with a .jpg extension.

Also addresses issue reported in BepisPlugins: https://github.com/IllusionMods/BepisPlugins/issues/214