### PR TITLE
[VE] Improvements and fixes for the reshade plugin

### DIFF
--- a/VideoExport.Core/ScreenshotPlugins/ReshadePlugin.cs
+++ b/VideoExport.Core/ScreenshotPlugins/ReshadePlugin.cs
@@ -3,6 +3,8 @@ using System.Runtime.InteropServices;
 using UnityEngine;
 using VideoExport.Core;
 using System.Reflection;
+using System.Linq;
+
 
 #if IPA
 using Harmony;
@@ -167,12 +169,10 @@ namespace VideoExport.ScreenshotPlugins
                         return "png";
                     case VideoExport.ImgFormat.JPG:
                         return "jpg";
-                    case VideoExport.ImgFormat.EXR:
-                        return "exr";
                 }
             }
         }
-        public byte bitDepth { get { return (byte)(this._imageFormat == VideoExport.ImgFormat.EXR ? 10 : 8); } }
+        public byte bitDepth { get { return 8; } }
 
         public VideoExport.ImgFormat imageFormat { get { return _imageFormat; } }
         private VideoExport.ImgFormat _imageFormat;
@@ -190,7 +190,7 @@ namespace VideoExport.ScreenshotPlugins
 #endif
         {
             this._imageFormat = (VideoExport.ImgFormat)VideoExport._configFile.AddInt("reshadeImageFormat", (int)VideoExport.ImgFormat.BMP, true);
-            this._imageFormatNames = Enum.GetNames(typeof(VideoExport.ImgFormat));
+            this._imageFormatNames = Enum.GetNames(typeof(VideoExport.ImgFormat)).Where(x => x != nameof(VideoExport.ImgFormat.EXR)).ToArray();
             this._autoHideUI = VideoExport._configFile.AddBool("autoHideUI", true, true);
             this._removeAlphaChannel = VideoExport._configFile.AddBool("removeAlphaChannel", true, true);
 

--- a/VideoExport.Core/ScreenshotPlugins/ReshadePlugin.cs
+++ b/VideoExport.Core/ScreenshotPlugins/ReshadePlugin.cs
@@ -89,29 +89,48 @@ namespace VideoExport.ScreenshotPlugins
             return _initialized && _shmFile != IntPtr.Zero && _shm != IntPtr.Zero;
         }
 
-        public static Texture2D RequestScreenshot()
+        public static Texture2D RequestScreenshot(bool removeAlpha)
         {
             Screenshot screenshot = (Screenshot)Marshal.PtrToStructure(_shm, typeof(Screenshot));
             uint imageSize = screenshot.width * screenshot.height * screenshot.channels;
             IntPtr imageBytesPtr = new IntPtr(_shm.ToInt64() + Marshal.SizeOf(typeof(Screenshot)));
-            byte[] imageData = new byte[imageSize];
-            Marshal.Copy(imageBytesPtr, imageData, 0, (int) imageSize);
+            byte[] rawImageBytes = new byte[imageSize];
+            Marshal.Copy(imageBytesPtr, rawImageBytes, 0, (int) imageSize);
 
-            // Image comes flipped vertically, so we flip it back to normal
-            byte[] flipped = new byte[imageSize];
+            // Raw image comes flipped vertically, so we flip it back to normal
+            byte[] bytesRGBA = new byte[imageSize];
             uint rowSize = screenshot.width * screenshot.channels;
             for (uint y = 0; y < screenshot.height; y++)
             {
                 uint srcRow = (screenshot.height - 1 - y) * rowSize;
                 uint dstRow = y * rowSize;
-                Buffer.BlockCopy(imageData, (int)srcRow, flipped, (int)dstRow, (int)rowSize);
+                Buffer.BlockCopy(rawImageBytes, (int)srcRow, bytesRGBA, (int)dstRow, (int)rowSize);
             }
 
-            Texture2D texture = new Texture2D((int)screenshot.width, (int)screenshot.height, TextureFormat.RGBA32, false);
-            texture.LoadRawTextureData(flipped);
-            texture.Apply();
+            if (removeAlpha)
+            {
+                uint rgbSize = screenshot.width * screenshot.height * 3;
+                byte[] bytesRGB = new byte[rgbSize];
 
-            return texture;
+                for (int src = 0, dst = 0; src < bytesRGBA.Length; src += 4, dst += 3)
+                {
+                    bytesRGB[dst] = bytesRGBA[src];
+                    bytesRGB[dst + 1] = bytesRGBA[src + 1];
+                    bytesRGB[dst + 2] = bytesRGBA[src + 2];
+                }
+
+                Texture2D texture = new Texture2D((int)screenshot.width, (int)screenshot.height, TextureFormat.RGB24, false, false);
+                texture.LoadRawTextureData(bytesRGB);
+                texture.Apply();
+                return texture;
+            }
+            else
+            {
+                Texture2D texture = new Texture2D((int)screenshot.width, (int)screenshot.height, TextureFormat.RGBA32, false, false);
+                texture.LoadRawTextureData(bytesRGBA);
+                texture.Apply();
+                return texture;
+            }
         }
     }
 
@@ -134,7 +153,7 @@ namespace VideoExport.ScreenshotPlugins
                 return new Vector2(width, height);
             }
         }
-        public bool transparency { get { return false; } }
+        public bool transparency { get { return !_removeAlphaChannel; } }
         public string extension
         {
             get
@@ -158,6 +177,7 @@ namespace VideoExport.ScreenshotPlugins
         public VideoExport.ImgFormat imageFormat { get { return _imageFormat; } }
         private VideoExport.ImgFormat _imageFormat;
         private bool _autoHideUI;
+        private bool _removeAlphaChannel;
         private string[] _imageFormatNames;
 
         Action _toggleUI = null;
@@ -172,6 +192,7 @@ namespace VideoExport.ScreenshotPlugins
             this._imageFormat = (VideoExport.ImgFormat)VideoExport._configFile.AddInt("reshadeImageFormat", (int)VideoExport.ImgFormat.BMP, true);
             this._imageFormatNames = Enum.GetNames(typeof(VideoExport.ImgFormat));
             this._autoHideUI = VideoExport._configFile.AddBool("autoHideUI", true, true);
+            this._removeAlphaChannel = VideoExport._configFile.AddBool("removeAlphaChannel", true, true);
 
             return ReshadeAPI.OpenSharedMemory();
         }
@@ -195,7 +216,7 @@ namespace VideoExport.ScreenshotPlugins
 
         public Texture2D CaptureTexture()
         {
-            return ReshadeAPI.RequestScreenshot();
+            return ReshadeAPI.RequestScreenshot(_removeAlphaChannel);
         }
 
         public void OnStartRecording()
@@ -234,6 +255,7 @@ namespace VideoExport.ScreenshotPlugins
             GUILayout.BeginHorizontal();
             {
                 this._autoHideUI = GUILayout.Toggle(_autoHideUI, "Auto Hide UI");
+                this._removeAlphaChannel = GUILayout.Toggle(_removeAlphaChannel, "Remove Alpha Channel");
             }
             GUILayout.EndHorizontal();
         }
@@ -242,6 +264,7 @@ namespace VideoExport.ScreenshotPlugins
         {
             VideoExport._configFile.SetInt("reshadeImageFormat", (int)this._imageFormat);
             VideoExport._configFile.SetBool("autoHideUI", (bool)this._autoHideUI);
+            VideoExport._configFile.SetBool("removeAlphaChannel", (bool)this._removeAlphaChannel);
         }
 
         private void InitializeToggleUI()


### PR DESCRIPTION
- Added a toggle for removing the alpha channel. Many effects zero out the alpha channel, causing fully transparent screenshots when encoding as PNG.
- Removed EXR because we currently only have the standard RGBA image format.
- Fixed auto-hide to work as the user expects (auto-hide now means hide, not toggle to the other state).