### PR TITLE
QoL update Colliders Editor | Force refresh colliders

### DIFF
--- a/Core.PoseEditor/AMModules/CollidersEditor.cs
+++ b/Core.PoseEditor/AMModules/CollidersEditor.cs
@@ -1496,7 +1496,8 @@ namespace HSPE.AMModules
         {
             return _isEnabled && PoseController._drawAdvancedMode && _colliderTarget != null;
         }
-        private void RefreshColliderList() // Force Refresh Colliders method
+
+        private void RefreshColliderList()
         {
             _colliders.Clear();
 

--- a/Core.PoseEditor/AMModules/CollidersEditor.cs
+++ b/Core.PoseEditor/AMModules/CollidersEditor.cs
@@ -645,7 +645,6 @@ namespace HSPE.AMModules
             }
             GUILayout.EndScrollView();
 
-            // Force refresh list button
             if (GUILayout.Button("Force refresh list"))
             {
                 RefreshColliderList();

--- a/Core.PoseEditor/AMModules/CollidersEditor.cs
+++ b/Core.PoseEditor/AMModules/CollidersEditor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
@@ -644,6 +644,12 @@ namespace HSPE.AMModules
                 GUI.color = c;
             }
             GUILayout.EndScrollView();
+
+            // Force refresh list button
+            if (GUILayout.Button("Force refresh list"))
+            {
+                RefreshColliderList();
+            }
 
             {
                 c = GUI.color;
@@ -1489,6 +1495,33 @@ namespace HSPE.AMModules
         private bool GizmosEnabled()
         {
             return _isEnabled && PoseController._drawAdvancedMode && _colliderTarget != null;
+        }
+        private void RefreshColliderList() // Force Refresh Colliders method
+        {
+            _colliders.Clear();
+
+            foreach (var c in _parent.GetComponentsInChildren<DynamicBoneColliderBase>(true))
+            {
+                if (!_colliders.ContainsKey(c.transform))
+                {
+                    _colliders.Add(c.transform, c);
+                    // UnityEngine.Debug.Log($"[Pose Editor] CollidersEditor: Found collider '{c.name}' on '{c.transform.GetPathFrom(_parent.transform)}'");
+                }
+            }
+
+#if AISHOUJO || HONEYSELECT2
+
+            foreach (var c in _parent.GetComponentsInChildren<DynamicBonePlaneCollider>(true))
+            {
+                if (!_colliders.ContainsKey(c.transform))
+                {
+                    _colliders.Add(c.transform, c);
+                    // UnityEngine.Debug.Log($"[Pose Editor] CollidersEditor: Found plane collider '{c.name}' on '{c.transform.GetPathFrom(_parent.transform)}'");
+                }
+            }
+#endif
+
+            _colliderTarget = _colliders.Values.FirstOrDefault();
         }
         #endregion
 


### PR DESCRIPTION
I was having a bug with colliders not being added to the colliders list properly when a new character was added to a scene, the colliders were only getting added to the list properly when you opened an existing scene with characters, only those that were already there had the full list. This manually fixes the issue to anybody that requires a refresh.

