### PR TITLE
[VE] GIF improvements and general fixes

### DIFF
--- a/VideoExport.Core/Extensions/AFFMPEGBasedExtension.cs
+++ b/VideoExport.Core/Extensions/AFFMPEGBasedExtension.cs
@@ -29,7 +29,7 @@ namespace VideoExport.Extensions
         private StringBuilder _errorBuilder = new StringBuilder();
 
         public virtual int progress { get { return this._progress; } }
-        public bool canProcessStandardOutput { get { return true; } }
+        public virtual bool canProcessStandardOutput { get { return true; } }
         public bool canProcessStandardError { get { return true; } }
 
         static AFFMPEGBasedExtension()

--- a/VideoExport.Core/Extensions/GIFExtension.cs
+++ b/VideoExport.Core/Extensions/GIFExtension.cs
@@ -1,34 +1,62 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
+using System.Linq;
 using System.Text;
 using UnityEngine;
 using VideoExport.ScreenshotPlugins;
 
 namespace VideoExport.Extensions
 {
-    public class GIFExtension : IExtension
+    public class GIFExtension : AFFMPEGBasedExtension
     {
         private readonly string _gifskiFolder;
         private readonly string _gifskiExe;
 
         private StringBuilder _errorBuilder = new StringBuilder();
 
-        public int progress { get { return 0; } }
-        public bool canProcessStandardOutput { get { return false; } }
-        public bool canProcessStandardError { get { return true; } }
+        public override bool canProcessStandardOutput { get { return _gifTool == GifTool.FFmpeg; } }
+
+        private enum GifTool
+        {
+            FFmpeg,
+            Gifski,
+        }
+
+        private enum Dithering
+        {
+            None,
+            Bayer,
+            FloydSteinberg,
+        }
+
+        private GifTool _gifTool;
+        private Dithering _ffmpegDithering;
+        private readonly string[] _gifToolNames = Enum.GetValues(typeof(GifTool)).Cast<GifTool>().Select(x => GetGifToolString(x)).ToArray();
+        private readonly string[] _ffmpegDitheringNames = Enum.GetValues(typeof(Dithering)).Cast<Dithering>().Select(x => GetDitheringString(x)).ToArray();
 
         public GIFExtension()
         {
             this._gifskiFolder = Path.Combine(VideoExport._pluginFolder, "gifski");
             this._gifskiExe = Path.GetFullPath(Path.Combine(this._gifskiFolder, "gifski.exe"));
+            this._gifTool = (GifTool)VideoExport._configFile.AddInt("gifTool", (int)GifTool.FFmpeg, true);
+            this._ffmpegDithering = (Dithering)VideoExport._configFile.AddInt("gifDithering", (int)Dithering.None, true);
         }
 
-        public void UpdateLanguage()
+        public bool IsPaletteGenRequired()
         {
+            return this._gifTool == GifTool.FFmpeg;
         }
 
-        public bool IsCompatibleWithPlugin(IScreenshotPlugin plugin, out string reason)
+        public override void UpdateLanguage()
         {
-            if (plugin.extension != "png")
+            if (_gifTool == GifTool.Gifski)
+                return;
+            base.UpdateLanguage();
+        }
+
+        public override bool IsCompatibleWithPlugin(IScreenshotPlugin plugin, out string reason)
+        {
+            if (this._gifTool == GifTool.Gifski && plugin.extension != "png")
             {
                 reason = VideoExport._currentDictionary.GetString(VideoExport.TranslationKey.GIFError);
                 return false;
@@ -42,45 +70,132 @@ namespace VideoExport.Extensions
             return true;
         }
 
-        public string GetExecutable()
+        public override string GetExecutable()
         {
-            return this._gifskiExe;
+            if (_gifTool == GifTool.Gifski)
+                return this._gifskiExe;
+            return base.GetExecutable();
         }
 
-        public string GetArguments(string framesFolder, string prefix, string postfix, string inputExtension, byte bitDepth, int fps, bool transparency, bool resize, int resizeX, int resizeY, string fileName)
+        public string GetArgumentsPaletteGen(string framesFolder, string prefix, string postfix, string inputExtension, byte bitDepth, int fps, bool transparency, bool resize, int resizeX, int resizeY, string fileName)
         {
-            return $"{(resize ? $"-W {resizeX} -H {resizeY}" : "")} --fps {fps} -o \"{fileName}.gif\" \"{framesFolder}\"\\{prefix}*{postfix}.{inputExtension} --quiet";
+            int coreCount = _coreCount;
+            string videoFilterArgument = $"-vf \"palettegen=stats_mode=diff\"";
+
+            string ffmpegArgs = $"-loglevel error -r {fps} -f image2 -threads {coreCount} -progress pipe:1";
+            string inputArgs = $"-i \"{framesFolder}\\{prefix}%d{postfix}.{inputExtension}\" {videoFilterArgument}";
+            string outputArgs = $"\"{fileName}.palette.png\"";
+
+            return $"{ffmpegArgs} {inputArgs} {outputArgs}";
         }
 
-        public string GetArguments(string framesFolder, string inputExtension, byte bitDepth, int fps, bool transparency, bool resize, int resizeX, int resizeY, string fileName)
+        public override string GetArguments(string framesFolder, string prefix, string postfix, string inputExtension, byte bitDepth, int fps, bool transparency, bool resize, int resizeX, int resizeY, string fileName)
         {
-            return GetArguments(framesFolder, "", "", inputExtension, bitDepth, fps, transparency, resize, resizeX, resizeY, fileName);
-        }
-
-        public void ResetProgress()
-        {
-        }
-
-        public void ProcessStandardOutput(char c)
-        {
-        }
-
-        public void ProcessStandardError(char c)
-        {
-            if (c == '\n')
+            if (this._gifTool == GifTool.Gifski)
             {
-                string line = this._errorBuilder.ToString();
-                VideoExport.Logger.LogWarning(line);
-                this._errorBuilder = new StringBuilder();
+                return $"{(resize ? $"-W {resizeX} -H {resizeY}" : "")} --fps {fps} -o \"{fileName}.gif\" \"{framesFolder}\"\\{prefix}*{postfix}.{inputExtension} --quiet";
             }
             else
-                this._errorBuilder.Append(c);
+            {
+                int coreCount = _coreCount;
+
+                string videoFilterArgument = CompileFiltersComplex(resize, resizeX, resizeY);
+
+                string ffmpegArgs = $"-loglevel error -r {fps} -f image2 -threads {coreCount} -progress pipe:1";
+                string inputArgs = $"-i \"{framesFolder}\\{prefix}%d{postfix}.{inputExtension}\" -i {fileName}.palette.png {videoFilterArgument}";
+                string outputArgs = $"\"{fileName}.gif\"";
+
+                return $"{ffmpegArgs} {inputArgs} {outputArgs}";
+            }
         }
 
-        public void DisplayParams()
+        public override void ProcessStandardOutput(char c)
         {
+            if (this._gifTool == GifTool.Gifski)
+                return;
+            base.ProcessStandardOutput(c);
         }
 
-        public void SaveParams() { }
+        public override void ProcessStandardError(char c)
+        {
+            if (this._gifTool == GifTool.Gifski)
+            {
+                if (c == '\n')
+                {
+                    string line = this._errorBuilder.ToString();
+                    VideoExport.Logger.LogWarning(line);
+                    this._errorBuilder = new StringBuilder();
+                }
+                else
+                    this._errorBuilder.Append(c);
+            }
+            else
+            {
+                base.ProcessStandardError(c);
+            }
+        }
+
+        public override void DisplayParams()
+        {
+            GUILayout.BeginHorizontal();
+            {
+                GUILayout.Label(new GUIContent(VideoExport._currentDictionary.GetString(VideoExport.TranslationKey.GIFTool), VideoExport._currentDictionary.GetString(VideoExport.TranslationKey.GIFToolTooltip).Replace("\\n", "\n")), GUILayout.ExpandWidth(false));
+                this._gifTool = (GifTool)GUILayout.SelectionGrid((int)this._gifTool, this._gifToolNames, 2);
+            }
+            GUILayout.EndHorizontal();
+
+            if (this._gifTool == GifTool.FFmpeg)
+            {
+                GUILayout.BeginVertical();
+                {
+                    GUILayout.Label(new GUIContent(VideoExport._currentDictionary.GetString(VideoExport.TranslationKey.GIFDithering), VideoExport._currentDictionary.GetString(VideoExport.TranslationKey.GIFDitheringTooltip).Replace("\\n", "\n")), GUILayout.ExpandWidth(false));
+                    this._ffmpegDithering = (Dithering)GUILayout.SelectionGrid((int)this._ffmpegDithering, this._ffmpegDitheringNames, 3);
+                }
+                GUILayout.EndVertical();
+
+                base.DisplayParams();
+            }
+        }
+
+        public override void SaveParams()
+        {
+            VideoExport._configFile.SetInt("gifTool", (int)this._gifTool);
+            VideoExport._configFile.SetInt("gifDithering", (int)this._ffmpegDithering);
+            base.SaveParams();
+        }
+
+        private string CompileFiltersComplex(bool resize, int resizeX, int resizeY)
+        {
+            string dithering = _ffmpegDitheringNames[(int)_ffmpegDithering];
+            string palette = $"paletteuse=dither={dithering}";
+
+            string rotate = string.Join(",", Enumerable.Repeat("transpose=1", (int)_rotation).ToArray());
+            string scale = resize ? $"scale={resizeX}x{resizeY}:flags=lanczos" : "";
+            string transform = $"{rotate}{(rotate != "" ? "," : "")}{scale}";
+
+            string complex_filter = $"-filter_complex \"[0:v]{transform}[v];[v][1:v]{palette}\"";
+            return complex_filter;
+        }
+
+        private static string GetDitheringString(Dithering dithering)
+        {
+            switch (dithering)
+            {
+                case Dithering.None: return "none";
+                case Dithering.Bayer: return "bayer";
+                case Dithering.FloydSteinberg: return "floyd_steinberg";
+            }
+            throw new NotImplementedException("Invalid dithering setting");
+        }
+
+        private static string GetGifToolString(GifTool tool)
+        {
+            switch (tool)
+            {
+                case GifTool.FFmpeg: return "FFmpeg";
+                case GifTool.Gifski: return "Gifski";
+            }
+            throw new NotImplementedException("Invalid gif tool");
+        }
     }
 }

--- a/VideoExport.Core/Extensions/WEBPExtension.cs
+++ b/VideoExport.Core/Extensions/WEBPExtension.cs
@@ -30,7 +30,7 @@ namespace VideoExport.Extensions
             string videoFilterArgument = this.CompileFilters(resize, resizeX, resizeY);
 
             string codec = _codecCLIOptions[(int)this._codec];
-            string codecExtraArgs = $"-qscale {this._quality}";
+            string codecExtraArgs = $"-qscale {this._quality} -loop 0";
 
             string ffmpegArgs = $"-loglevel error -r {fps} -f image2 -threads {coreCount} -progress pipe:1";
             string inputArgs = $"-i \"{framesFolder}\\{prefix}%d{postfix}.{inputExtension}\" -pix_fmt {pixFmt} {videoFilterArgument}";

--- a/VideoExport.Core/Resources/English.xml
+++ b/VideoExport.Core/Resources/English.xml
@@ -76,6 +76,8 @@
   <string key="OtherSettingsHeading" value="Other Settings" />
   <string key="ScreenshotTool" value="Screenshot Tool" />
   <string key="Extension" value="Extension" />
+  <string key="GIFTool" value="GIF Tool" />
+  <string key="GIFDithering" value="Dithering" />
   <string key="CreateVideo" value="Create Video" />
   <string key="AutoHideUI" value="Auto Hide UI"/>
   <string key="RemoveAlphaChannel" value="Remove Alpha Channel"/>
@@ -98,4 +100,6 @@
   <string key="MOVCodecTooltip" value="[ProRes4444] Produces very large files meant for professional video editing." />
   <string key="AVIFCodecTooltip" value="[Libaom-av1] Widely supported, lossless quality, slow encoding.\n[Libsvt-av1] Good quality, fast encoding." />
   <string key="HwAccelCodecTooltip" value="Fast encoding using GPU accelerated codecs.\nLess efficient, produces larger files for the same quality."/>
+  <string key="GIFToolTooltip" value="[FFmpeg] Good quality, widely supported. Slightly larger.\n         Global palette, 256 colors total. Dithering optional.\n[Gifsky] Highest quality, smoother, but may cause flickering.\n         Local palette, 256 colors per frame. Dithering mandatory." />
+  <string key="GIFDitheringTooltip" value="Fakes colors outside of the limited palette:\n[none] No dithering. Recommended until visually necessary.\n[bayer] Creates visible dither patterns/aesthetic.\n[floyd_steinberg] Creates smooth gradients and relatively low noise." />
 </root>

--- a/VideoExport.Core/Resources/English.xml
+++ b/VideoExport.Core/Resources/English.xml
@@ -53,7 +53,7 @@
   <string key="Rotation180" value="180°" />
   <string key="Rotation270" value="90° CCW" />
   <string key="BitDepthError" value="The current video format does not support this bit depth." />
-  <string key="GIFError" value="GIF is only compatible with PNG images." />
+  <string key="GIFError" value="Gifski tool is only compatible with PNG images." />
   <string key="Codec" value="Codec" />
   <string key="HwAccelCodec" value="Use GPU-accelerated codec" />
   <string key="MP4Preset" value="Encoding Preset" />

--- a/VideoExport.Core/Resources/English.xml
+++ b/VideoExport.Core/Resources/English.xml
@@ -77,6 +77,7 @@
   <string key="ScreenshotTool" value="Screenshot Tool" />
   <string key="Extension" value="Extension" />
   <string key="GIFTool" value="GIF Tool" />
+  <string key="GIFMaxColors" value="Max Colors" />
   <string key="GIFDithering" value="Dithering" />
   <string key="CreateVideo" value="Create Video" />
   <string key="AutoHideUI" value="Auto Hide UI"/>

--- a/VideoExport.Core/Resources/中文.xml
+++ b/VideoExport.Core/Resources/中文.xml
@@ -75,6 +75,8 @@
   <string key="OtherSettingsHeading" value="其他设置" />
   <string key="ScreenshotTool" value="截图工具" />
   <string key="Extension" value="扩展名" />
+  <string key="GIFTool" value="GIF 工具" />
+  <string key="GIFDithering" value="抖动" />
   <string key="CreateVideo" value="创建视频" />
   <string key="AutoHideUI" value="自动隐藏界面" />
   <string key="RemoveAlphaChannel" value="移除透明通道" />
@@ -97,4 +99,6 @@
   <string key="MOVCodecTooltip" value="[ProRes4444] 生成用于专业视频编辑的超大文件。" />
   <string key="AVIFCodecTooltip" value="[Libaom-av1] 广泛支持，无损画质，编码较慢。\n[Libsvt-av1] 良好画质（有损），编码快速。" />
   <string key="HwAccelCodecTooltip" value="使用 GPU 加速编码快速生成视频。\n压缩效率较低，同质量下文件更大。" />
+  <string key="GIFToolTooltip" value="[FFmpeg] 质量好，支持广泛。文件稍大。\n         全局调色板，总共256色。抖动可选。\n[Gifsky] 最高质量，更平滑，但可能闪烁。\n         局部调色板，每帧256色。抖动必需。" />
+  <string key="GIFDitheringTooltip" value="模拟有限调色板外的颜色：\n[none] 无抖动。推荐默认使用，直到视觉需要。\n[bayer] 产生明显的抖动图案/美感。\n[floyd_steinberg] 产生平滑渐变且噪点较低。" />
 </root>

--- a/VideoExport.Core/Resources/中文.xml
+++ b/VideoExport.Core/Resources/中文.xml
@@ -53,7 +53,7 @@
   <string key="Rotation180" value="旋转180°" />
   <string key="Rotation270" value="旋转-90°" />
   <string key="BitDepthError" value="当前视频格式无法支持此位深效果" />
-  <string key="GIFError" value="GIF与PNG只能二选其一" />
+  <string key="GIFError" value="Gifski 工具仅兼容 PNG 图像。" />
   <string key="Codec" value="编码器" />
   <string key="HwAccelCodec" value="使用 GPU 加速编解码器" />
   <string key="MP4Preset" value="编码预设" />

--- a/VideoExport.Core/Resources/中文.xml
+++ b/VideoExport.Core/Resources/中文.xml
@@ -76,6 +76,7 @@
   <string key="ScreenshotTool" value="截图工具" />
   <string key="Extension" value="扩展名" />
   <string key="GIFTool" value="GIF 工具" />
+  <string key="GIFMaxColors" value="最大颜色数" />
   <string key="GIFDithering" value="抖动" />
   <string key="CreateVideo" value="创建视频" />
   <string key="AutoHideUI" value="自动隐藏界面" />

--- a/VideoExport.Core/Styles.cs
+++ b/VideoExport.Core/Styles.cs
@@ -20,7 +20,6 @@ namespace VideoExport
 
 
         public static GUIStyle ToggleStyle;
-        public static GUIStyle SliderStyle;
         public static GUIStyle TextFieldStyle;
         public static GUIStyle LabelStyle;
         public static GUIStyle CenteredLabelStyle;
@@ -42,7 +41,6 @@ namespace VideoExport
             _veSkin.label = LabelStyle;
             _veSkin.button = ButtonStyle;
             _veSkin.textField = TextFieldStyle;
-            _veSkin.horizontalSlider = SliderStyle;
         }
 
         private static void InitializeStyles()
@@ -55,13 +53,6 @@ namespace VideoExport
                 onHover = { textColor = Color.yellow },
                 onNormal = { textColor = NormalColorOn },
                 padding = new RectOffset(20, 5, 3, 3),
-            };
-
-            SliderStyle = new GUIStyle(_originalSkin.horizontalSlider)
-            {
-                fontSize = CommonFontSize,
-                alignment = TextAnchor.MiddleLeft,
-                padding = new RectOffset(5, 5, 3, 3),
             };
 
             TextFieldStyle = new GUIStyle(_originalSkin.textField)

--- a/VideoExport.Core/VideoExport.cs
+++ b/VideoExport.Core/VideoExport.cs
@@ -308,6 +308,7 @@ namespace VideoExport
             _showVideoSection = _configFile.AddBool("showVideoSection", true, true);
             _showOtherSection = _configFile.AddBool("showOtherSection", true, true);
             _showTooltips = _configFile.AddBool("showTooltips", true, true);
+            _parallelScreenshotEncoding = _configFile.AddBool("parallelScreenshotEncoding", false, true);
             _language = Config.Bind(Name, "Language", Language.English, "Interface language");
             _language.SettingChanged += (sender, args) => SetLanguage(_language.Value);
             SetLanguage(_language.Value);
@@ -449,6 +450,7 @@ namespace VideoExport
             _configFile.SetBool("showVideoSection", _showVideoSection);
             _configFile.SetBool("showOtherSection", _showOtherSection);
             _configFile.SetBool("showTooltips", _showTooltips);
+            _configFile.SetBool("parallelScreenshotEncoding", _parallelScreenshotEncoding);
             foreach (IScreenshotPlugin plugin in _screenshotPlugins)
                 plugin.SaveParams();
             foreach (IExtension extension in _extensions)
@@ -853,7 +855,7 @@ namespace VideoExport
                 GUILayout.BeginHorizontal("Box");
                 {
                     GUILayout.BeginVertical();
-                    _autoDeleteImages = GUILayout.Toggle(_autoDeleteImages, "Auto Delete Screenshots");
+                    _autoDeleteImages = GUILayout.Toggle(_autoDeleteImages, _currentDictionary.GetString(TranslationKey.AutoDeleteImages));
                     GUILayout.EndVertical();
 
                     GUILayout.BeginVertical();
@@ -1266,7 +1268,6 @@ namespace VideoExport
                 if (_selectedExtension == ExtensionsType.GIF && (extension as GIFExtension)?.IsPaletteGenRequired() == true)
                 {
                     string arguments_palettegen = (extension as GIFExtension).GetArgumentsPaletteGen(SimplifyPath(framesFolder), "", "", imageExtension, screenshotPlugin.bitDepth, _exportFps, screenshotPlugin.transparency, _resize, _resizeX, _resizeY, fileName);
-                    extension.ResetProgress();
                     Process proc_palettegen = StartExternalProcess(extension.GetExecutable(), arguments_palettegen, false, extension.canProcessStandardError);
                     yield return StartCoroutine(HandleProcessOutput(proc_palettegen, totalFrames, false, val => error = val));
                 }

--- a/VideoExport.Core/VideoExport.cs
+++ b/VideoExport.Core/VideoExport.cs
@@ -150,6 +150,7 @@ namespace VideoExport
             WEBPQuality,
             AVIFQuality,
             GIFTool,
+            GIFMaxColors,
             GIFDithering,
             ShowTooltips,
             CaptureSettingsHeading,


### PR DESCRIPTION
The `gifski` tool generates per-frame color palettes with mandatory dithering, which causes flickering in Discord. This PR adds an option to generate GIFs with `ffmpeg`. In this case we need to run `ffmpeg` external process twice: first to generate a global color palette, then the image generation itself.

It ended up a bit of a conditional mess because `ffmpeg` palette generation and `gifski` do not have standard output. But I am keeping `gifski` because `ffmpeg` can't do per-frame palettes.

External process standard output is now handled async + a few misc fixes.