### PR TITLE
remove null reference during destroy on PoseEditor

### DIFF
--- a/Core.PoseEditor/CharaPoseController.cs
+++ b/Core.PoseEditor/CharaPoseController.cs
@@ -367,8 +367,11 @@ namespace HSPE
 
         protected override void OnDestroy()
         {
-            _body.solver.spineStiffness = _cachedSpineStiffness;
-            _body.solver.pullBodyVertical = _cachedPullBodyVertical;
+            if (_body != null && _body.solver != null)
+            {
+                _body.solver.spineStiffness = _cachedSpineStiffness;
+                _body.solver.pullBodyVertical = _cachedPullBodyVertical;
+            }
             IKSolver_Patches.onPostUpdate -= IKSolverOnPostUpdate;
             IKExecutionOrder_Patches.onPostLateUpdate -= IKExecutionOrderOnPostLateUpdate;
             FKCtrl_Patches.onPreLateUpdate -= FKCtrlOnPreLateUpdate;


### PR DESCRIPTION
issue:
when i try to exit studio, i meet null reference like below

NullReferenceException
  at (wrapper managed-to-native) UnityEngine.Component.get_gameObject(UnityEngine.Component)
  at HSPE.AMModules.BlendShapesEditor.OnDisable () [0x0003b] in <57951205e4844ff1af8e92ebb1481ac1>:0 
  at (wrapper delegate-invoke) <Module>.invoke_void()
  at HSPE.PoseController.OnDisable () [0x00000] in <57951205e4844ff1af8e92ebb1481ac1>:0

solution:
check null pointer before variable used.
