### PR TITLE
[VE] Tag video color matrix/range to fix discoloration (#198)

### DIFF
--- a/VideoExport.Core/VideoExtensions/AFFMPEGBasedExtension.cs
+++ b/VideoExport.Core/VideoExtensions/AFFMPEGBasedExtension.cs
@@ -23,7 +23,7 @@ namespace VideoExport.VideoExtensions
         protected static Rotation _rotation = Rotation.None;
         protected int _progress;
         protected static readonly int _coreCount;
-        protected bool _needsVFlip = true; 
+        protected bool _needsVFlip = true;
 
         private StringBuilder _outputBuilder = new StringBuilder();
         private StringBuilder _errorBuilder = new StringBuilder();
@@ -193,6 +193,23 @@ namespace VideoExport.VideoExtensions
         public void SetVFlipNeeded(bool needsVFlip)
         {
             _needsVFlip = needsVFlip;
+        }
+
+        protected void BuildCommonArgs(string framesFolder, int fps, string videoFilterArgument, string codecArgs,
+            string fileName, string extension,
+            out string inputArgs, out string filterArgs, out string mapArgs, out string finalCodecArgs, out string outputArgs,
+            bool tagColor = true)
+        {
+            string channelTypeArg = ((ChannelType)channelType).ToString().ToLower();
+            inputArgs = $"-loglevel error -r {fps} -f rawvideo -threads {_coreCount - 1} -pix_fmt {channelTypeArg} -i {framesFolder}";
+            filterArgs = $"[0:v]{videoFilterArgument}[vid]";
+            mapArgs = "-map [vid]";
+            // Tag the stream's color matrix and range so players don't guess and mis-decode the colors
+            // (issue #198). GIF passes false (palette, no YUV range to signal).
+            finalCodecArgs = tagColor
+                ? $"{codecArgs} -colorspace bt709 -color_primaries bt709 -color_trc bt709 -color_range tv"
+                : codecArgs;
+            outputArgs = $"\"{fileName}.{extension}\"";
         }
     }
 }

--- a/VideoExport.Core/VideoExtensions/AVIFExtension.cs
+++ b/VideoExport.Core/VideoExtensions/AVIFExtension.cs
@@ -26,9 +26,7 @@ namespace VideoExport.VideoExtensions
         public override void GetArguments(string framesFolder, string prefix, string postfix, string inputExtension, byte bitDepth, int fps, bool transparency, bool resize, int resizeX, int resizeY, string fileName,
             out string inputArgs, out string filterArgs, out string mapArgs, out string codecArgs, out string outputArgs)
         {
-            int coreCount = _coreCount;
             string pixFmt = transparency ? "yuva420p" : "yuv420p";
-            string channelTypeArg = ((ChannelType)channelType).ToString().ToLower();
 
             string videoFilterArgument = this.CompileFilters(resize, resizeX, resizeY);
 
@@ -40,12 +38,9 @@ namespace VideoExport.VideoExtensions
             }
             string rateControlArgument = $"-crf {_quality} -b:v 0";
 
-            string ffmpegArgs = $"-loglevel error -r {fps} -f rawvideo -threads {coreCount - 1}";
-            inputArgs = $"{ffmpegArgs} -pix_fmt {channelTypeArg} -i {framesFolder}";
-            filterArgs = $"[0:v]{videoFilterArgument}[vid]";
-            mapArgs = "-map [vid]";
-            codecArgs = $"-c:v {codec} {codecExtraArgs} {rateControlArgument} -pix_fmt {pixFmt}";
-            outputArgs = $"\"{fileName}.avif\"";
+            BuildCommonArgs(framesFolder, fps, videoFilterArgument,
+                $"-c:v {codec} {codecExtraArgs} {rateControlArgument} -pix_fmt {pixFmt}",
+                fileName, "avif", out inputArgs, out filterArgs, out mapArgs, out codecArgs, out outputArgs);
         }
 
         public override bool IsCompatibleWithPlugin(IScreenshotPlugin plugin, out string reason)

--- a/VideoExport.Core/VideoExtensions/GIFExtension.cs
+++ b/VideoExport.Core/VideoExtensions/GIFExtension.cs
@@ -124,21 +124,14 @@ namespace VideoExport.VideoExtensions
         public override void GetArguments(string framesFolder, string prefix, string postfix, string inputExtension, byte bitDepth, int fps, bool transparency, bool resize, int resizeX, int resizeY, string fileName,
             out string inputArgs, out string filterArgs, out string mapArgs, out string codecArgs, out string outputArgs)
         {
-            int coreCount = _coreCount;
-            string channelTypeArg = ((ChannelType)channelType).ToString().ToLower();
-
             string codec = "prores_ks";
             string codecProfileName = "4";
             string codecExtraArgs = "-profile:v " + codecProfileName;
             string videoPixelFormatArg = transparency ? "yuva444p10le" : "yuv444p10le";
             string videoFilterArgument = this.CompileFilters(resize, resizeX, resizeY, additionalFiltersPost: $"format={videoPixelFormatArg}");
 
-            string ffmpegArgs = $"-loglevel error -r {fps} -f rawvideo -threads {coreCount - 1}";
-            inputArgs = $"{ffmpegArgs} -pix_fmt {channelTypeArg} -i {framesFolder}";
-            filterArgs = $"[0:v]{videoFilterArgument}[vid]";
-            mapArgs = "-map [vid]";
-            codecArgs = $"-c:v {codec} {codecExtraArgs}";
-            outputArgs = $"\"{fileName}.mov\"";
+            BuildCommonArgs(framesFolder, fps, videoFilterArgument, $"-c:v {codec} {codecExtraArgs}",
+                fileName, "mov", out inputArgs, out filterArgs, out mapArgs, out codecArgs, out outputArgs, tagColor: false);
         }
 
         public override void ProcessStandardOutput(char c)

--- a/VideoExport.Core/VideoExtensions/MKVExtension.cs
+++ b/VideoExport.Core/VideoExtensions/MKVExtension.cs
@@ -29,21 +29,15 @@ namespace VideoExport.VideoExtensions
         public override void GetArguments(string framesFolder, string prefix, string postfix, string inputExtension, byte bitDepth, int fps, bool transparency, bool resize, int resizeX, int resizeY, string fileName,
             out string inputArgs, out string filterArgs, out string mapArgs, out string codecArgs, out string outputArgs)
         {
-            int coreCount = _coreCount;
             string pixFmt = transparency ? "yuva444p" : "yuv444p";
-            string channelTypeArg = ((ChannelType)channelType).ToString().ToLower();
 
             string videoFilterArgument = this.CompileFilters(resize, resizeX, resizeY, additionalFiltersPost: $"format={pixFmt}");
 
             string codec = _codecCLIOptions[(int)this._codec] + " -level 3";
             string codecExtraArgs = $"-g {this._gopSize} -slices {this._slices}";
 
-            string ffmpegArgs = $"-loglevel error -r {fps} -f rawvideo -threads {coreCount - 1}";
-            inputArgs = $"{ffmpegArgs} -pix_fmt {channelTypeArg} -i {framesFolder}";
-            filterArgs = $"[0:v]{videoFilterArgument}[vid]";
-            mapArgs = "-map [vid]";
-            codecArgs = $"-c:v {codec} {codecExtraArgs}";
-            outputArgs = $"\"{fileName}.mkv\"";
+            BuildCommonArgs(framesFolder, fps, videoFilterArgument, $"-c:v {codec} {codecExtraArgs}",
+                fileName, "mkv", out inputArgs, out filterArgs, out mapArgs, out codecArgs, out outputArgs);
         }
 
         public override bool IsCompatibleWithPlugin(IScreenshotPlugin plugin, out string reason)

--- a/VideoExport.Core/VideoExtensions/MOVExtension.cs
+++ b/VideoExport.Core/VideoExtensions/MOVExtension.cs
@@ -37,9 +37,6 @@ namespace VideoExport.VideoExtensions
         public override void GetArguments(string framesFolder, string prefix, string postfix, string inputExtension, byte bitDepth, int fps, bool transparency, bool resize, int resizeX, int resizeY, string fileName,
             out string inputArgs, out string filterArgs, out string mapArgs, out string codecArgs, out string outputArgs)
         {
-            int coreCount = _coreCount;
-            string channelTypeArg = ((ChannelType)channelType).ToString().ToLower();
-
             string codec = _codecCLIOptions[(int)this._codec];
             string codecProfileName = _codecProfiles[(int)this._codecProfile];
             string codecExtraArgs = "-profile:v " + codecProfileName;
@@ -50,12 +47,8 @@ namespace VideoExport.VideoExtensions
             }
             string videoFilterArgument = this.CompileFilters(resize, resizeX, resizeY, additionalFiltersPost: $"format={videoPixelFormatArg}");
 
-            string ffmpegArgs = $"-loglevel error -r {fps} -f rawvideo -threads {coreCount - 1}";
-            inputArgs = $"{ffmpegArgs} -pix_fmt {channelTypeArg} -i {framesFolder}";
-            filterArgs = $"[0:v]{videoFilterArgument}[vid]";
-            mapArgs = "-map [vid]";
-            codecArgs = $"-c:v {codec} {codecExtraArgs}";
-            outputArgs = $"\"{fileName}.mov\"";
+            BuildCommonArgs(framesFolder, fps, videoFilterArgument, $"-c:v {codec} {codecExtraArgs}",
+                fileName, "mov", out inputArgs, out filterArgs, out mapArgs, out codecArgs, out outputArgs);
         }
 
         public override void UpdateLanguage()

--- a/VideoExport.Core/VideoExtensions/MP4Extension.cs
+++ b/VideoExport.Core/VideoExtensions/MP4Extension.cs
@@ -91,8 +91,6 @@ namespace VideoExport.VideoExtensions
                     break;
             }
 
-            int coreCount = _coreCount;
-            string channelTypeArg = ((ChannelType)channelType).ToString().ToLower();
             string[] codecOptions = _codecCLIOptions;
             string codec = codecOptions[(int)this._codec];
             string tuneArgument = (codec == "libx264") ? "-tune animation" : "";
@@ -168,12 +166,9 @@ namespace VideoExport.VideoExtensions
                 codec = codecOptions[(int)this._codec];
             }
 
-            string ffmpegArgs = $"-loglevel error -r {fps} -f rawvideo -threads {coreCount - 1}";
-            inputArgs = $"{ffmpegArgs} -pix_fmt {channelTypeArg} -i {framesFolder}";
-            filterArgs = $"[0:v]{videoFilterArgument}[vid]";
-            mapArgs = "-map [vid]";
-            codecArgs = $"-c:v {codec} {tuneArgument} {presetArgument} {rateControlArgument} -pix_fmt {pixFmt}";
-            outputArgs = $"\"{fileName}.mp4\"";
+            BuildCommonArgs(framesFolder, fps, videoFilterArgument,
+                $"-c:v {codec} {tuneArgument} {presetArgument} {rateControlArgument} -pix_fmt {pixFmt}",
+                fileName, "mp4", out inputArgs, out filterArgs, out mapArgs, out codecArgs, out outputArgs);
         }
 
         public override void UpdateLanguage()

--- a/VideoExport.Core/VideoExtensions/WEBMExtension.cs
+++ b/VideoExport.Core/VideoExtensions/WEBMExtension.cs
@@ -72,28 +72,24 @@ namespace VideoExport.VideoExtensions
         public override void GetArguments(string framesFolder, string prefix, string postfix, string inputExtension, byte bitDepth, int fps, bool transparency, bool resize, int resizeX, int resizeY, string fileName,
             out string inputArgs, out string filterArgs, out string mapArgs, out string codecArgs, out string outputArgs)
         {
-            int coreCount = _coreCount;
             string pixFmt;
             switch (bitDepth)
             {
                 default:
                 case 8:
-                    pixFmt = transparency ? "yuva420p -metadata:s:v:0 alpha_mode=\"1\"" : "yuv420p";
+                    pixFmt = transparency ? "yuva420p" : "yuv420p";
                     break;
                 case 10:
-                    pixFmt = transparency ? "yuva420p10le -metadata:s:v:0 alpha_mode=\"1\"" : "yuv420p10le";
+                    pixFmt = transparency ? "yuva420p10le" : "yuv420p10le";
                     break;
             }
-            string channelTypeArg = ((ChannelType)channelType).ToString().ToLower();
+            string alphaMeta = transparency ? " -metadata:s:v:0 alpha_mode=\"1\"" : "";
             string autoAltRef = this._codec == Codec.VP8 ? "-auto-alt-ref 0" : "";
             string videoFilterArgument = this.CompileFilters(resize, resizeX, resizeY);
 
-            string ffmpegArgs = $"-loglevel error -r {fps} -f rawvideo -threads {coreCount - 1}";
-            inputArgs = $"{ffmpegArgs} -pix_fmt {channelTypeArg} -i {framesFolder}";
-            filterArgs = $"[0:v]{videoFilterArgument}[vid]";
-            mapArgs = "-map [vid]";
-            codecArgs = $"-c:v libvpx{(this._codec == Codec.VP9 ? "-vp9" : "")} -pix_fmt {pixFmt} {autoAltRef} -b:v {(_codec == Codec.VP9 ? "0" : _maxBitrate)} -crf {this._quality} -deadline {this._deadlineCLIOptions[(int)this._deadline]}";
-            outputArgs = $"\"{fileName}.webm\"";
+            BuildCommonArgs(framesFolder, fps, videoFilterArgument,
+                $"-c:v libvpx{(this._codec == Codec.VP9 ? "-vp9" : "")} -pix_fmt {pixFmt}{alphaMeta} {autoAltRef} -b:v {(_codec == Codec.VP9 ? "0" : _maxBitrate)} -crf {this._quality} -deadline {this._deadlineCLIOptions[(int)this._deadline]}",
+                fileName, "webm", out inputArgs, out filterArgs, out mapArgs, out codecArgs, out outputArgs);
         }
 
         public override void UpdateLanguage()

--- a/VideoExport.Core/VideoExtensions/WEBPExtension.cs
+++ b/VideoExport.Core/VideoExtensions/WEBPExtension.cs
@@ -25,21 +25,16 @@ namespace VideoExport.VideoExtensions
         public override void GetArguments(string framesFolder, string prefix, string postfix, string inputExtension, byte bitDepth, int fps, bool transparency, bool resize, int resizeX, int resizeY, string fileName,
             out string inputArgs, out string filterArgs, out string mapArgs, out string codecArgs, out string outputArgs)
         {
-            int coreCount = _coreCount;
             string pixFmt = transparency ? "yuva420p" : "yuv420p";
-            string channelTypeArg = ((ChannelType)channelType).ToString().ToLower();
 
             string videoFilterArgument = this.CompileFilters(resize, resizeX, resizeY);
 
             string codec = _codecCLIOptions[(int)this._codec];
             string codecExtraArgs = $"-qscale {this._quality} -loop 0";
 
-            string ffmpegArgs = $"-loglevel error -r {fps} -f rawvideo -threads {coreCount - 1}";
-            inputArgs = $"{ffmpegArgs} -pix_fmt {channelTypeArg} -i {framesFolder}";
-            filterArgs = $"[0:v]{videoFilterArgument}[vid]";
-            mapArgs = "-map [vid]";
-            codecArgs = $"-c:v {codec} {codecExtraArgs} -pix_fmt {pixFmt}";
-            outputArgs = $"\"{fileName}.webp\"";
+            BuildCommonArgs(framesFolder, fps, videoFilterArgument,
+                $"-c:v {codec} {codecExtraArgs} -pix_fmt {pixFmt}",
+                fileName, "webp", out inputArgs, out filterArgs, out mapArgs, out codecArgs, out outputArgs);
         }
 
         public override bool IsCompatibleWithPlugin(IScreenshotPlugin plugin, out string reason)


### PR DESCRIPTION
 ## Description
Tag the encoded video stream with its color matrix and range (`-colorspace bt709 -color_primaries bt709 -color_trc bt709 -color_range tv`) on all YUV encoders: MP4, WEBM, WEBP, AVIF, MKV, MOV. GIF stays untagged (palette format, no YUV range to signal). No pixel conversion or filter is added, only metadata through a shared `BuildCommonArgs` helper so every encoder tags consistently.

  ## Motivation and Context
Without color metadata, players had to guess the matrix (BT.709 vs BT.601) and range (limited vs full) when decoding YUV back to RGB. A wrong guess shifts the whole frame (The discoloration in #198 ). It only reproduced on some setups because the result depends on the player's guess, not the file. Tagging removes the guesswork.
  
  Fixes #198.

  ## How Has This Been Tested?
  - Untagged vs in-game reference: RMSE 0.0227; tagged: 0.0091 (2.5x closer, channel means within 0.2). Verified in a player, not by frame-extraction (extraction decodes correctly and hides the bug).
  - Tested with saturated color swatches round-tripped through the bundled ffmpeg decode correctly under BT.709 +-1–2 (levels per channel 0-255). Forced BT.601 is off by ~20 so the encoder actually writes BT.709.
  - Confirmed on a full-saturation gradient scene: tagged output matches in-game at RMSE 0.0087.
  - Builds for all 4 games, tested ok on KK and HS2 (non async vs async path)

| Metric (vs in-game reference) | 000 untagged | 001 tagged | Better |
  |---|---|---|---|
  | PSNR | 31.61 dB | **39.56 dB** | higher |
  | RMSE | 0.0263 | **0.0105** | lower |
  | RMSE green channel | 0.0345 | **0.0057** | lower |
  | FUZZ | 0.000885 | **0.000170** | lower |
  | Pixels differing (AE, fuzz 1%) | 72.4% | **21.8%** | lower |
  | Mean color shift (R/G/B) | −2.4 / **−5.1** / +1.1 | **+0.1 / +0.1 / −0.1** | ~0 |

Small shifts are expected due to encoding artifacts, same settings used for both 000 and 001 apart from tags.

  ## Screenshots (if appropriate):
Reference (made with F11)
<img width="1920" height="1080" alt="Screenshot" src="https://github.com/user-attachments/assets/2b777762-8043-4366-8d8d-4fcd657d158f" />
000 untagged (VE)
<img width="1920" height="1080" alt="000" src="https://github.com/user-attachments/assets/5aa8b68d-d62c-4be8-9903-1046eebd4126" />
001 tagged (VE)
<img width="1920" height="1080" alt="001" src="https://github.com/user-attachments/assets/d19ff460-f255-41b4-a04c-f447e535459c" />
Ref vs 000 fuzz 1%
<img width="1920" height="1080" alt="diff_000_fuzz1" src="https://github.com/user-attachments/assets/adfb10f9-8eb5-4ffa-ac7d-217aa6372812" />
Ref vs 001 fuzz 1%
<img width="1920" height="1080" alt="diff_001_fuzz1" src="https://github.com/user-attachments/assets/9760834a-b3e1-4d74-ba67-118b6e4f97c7" />

  ## Types of changes
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)