### PR TITLE
[VE] Fix buffer overrun recording in ScreenshotManager 180 mode

### DIFF
--- a/VideoExport.AI/VideoExport.AI.csproj
+++ b/VideoExport.AI/VideoExport.AI.csproj
@@ -5,7 +5,7 @@
 		<AssemblyName>VideoExport</AssemblyName>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="ScreenshotManager.AIGirl" Version="21.0.0" />
+		<PackageReference Include="ScreenshotManager.AIGirl" Version="21.1.2" />
 		<PackageReference Include="IllusionModdingAPI.AIAPI" Version="1.43.0" />
 	</ItemGroup>
 	<Import Project="..\VideoExport.Core\VideoExport.Core.projitems" Label="Shared" />

--- a/VideoExport.Core/ScreenshotPlugins/ScreencapPlugin.cs
+++ b/VideoExport.Core/ScreenshotPlugins/ScreencapPlugin.cs
@@ -38,7 +38,8 @@ namespace VideoExport.ScreenshotPlugins
                         if (_in3d) size.x = (size.x - (int)(size.x * ImageSeparationOffset.Value)) * 2;
                         return size;
                     case CaptureType.ThreeHundredSixty:
-                        size = new Vector2(Resolution360.Value, Mathf.FloorToInt(Resolution360.Value / 2f));
+                        float width360 = is180.Value ? Resolution360.Value / 2f : Resolution360.Value;
+                        size = new Vector2(width360, Mathf.FloorToInt(Resolution360.Value / 2f));
                         if (_in3d) size.x *= 2;
                         return size;
                     default:

--- a/VideoExport.Core/VideoExport.cs
+++ b/VideoExport.Core/VideoExport.cs
@@ -1369,6 +1369,7 @@ namespace VideoExport
                                 _asyncGPURequestCount++;
                                 var req = AsyncGPUReadback.Request(rt, 0, (request) => OnCompleteReadback(request, rt));
 #endif
+                                generatedFrames++;
                             }
                             else
                             {
@@ -1543,6 +1544,12 @@ namespace VideoExport
 
             if (_autoGenerateVideo)
             {
+                if (generatedFrames == 0)
+                {
+                    Logger.LogError("No frames were captured — the screenshot plugin returned no texture for the " +
+                                    "entire recording, so the video will be empty. If using Screenshot Manager 360 capture, check its settings.");
+                    _currentMessage = _currentDictionary.GetString(TranslationKey.GeneratingError);
+                }
 #if (!KOIKATSU || SUNSHINE)
                 // Tell the async writer no more frames are coming so it closes ffmpeg's stdin (else WaitForFFmpegExit deadlocks).
                 _ffmpegInputComplete = true;

--- a/VideoExport.HS2/VideoExport.HS2.csproj
+++ b/VideoExport.HS2/VideoExport.HS2.csproj
@@ -5,7 +5,7 @@
 		<AssemblyName>VideoExport</AssemblyName>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="ScreenshotManager.HoneySelect2" Version="21.0.0" />
+		<PackageReference Include="ScreenshotManager.HoneySelect2" Version="21.1.2" />
 		<PackageReference Include="IllusionModdingAPI.HS2API" Version="1.43.0" />
 	</ItemGroup>
 	<Import Project="..\VideoExport.Core\VideoExport.Core.projitems" Label="Shared" />

--- a/VideoExport.KK/VideoExport.KK.csproj
+++ b/VideoExport.KK/VideoExport.KK.csproj
@@ -5,7 +5,7 @@
 		<AssemblyName>VideoExport</AssemblyName>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="ScreenshotManager.Koikatu" Version="21.0.0" />
+		<PackageReference Include="ScreenshotManager.Koikatu" Version="21.1.2" />
 		<PackageReference Include="IllusionModdingAPI.KKAPI" Version="1.43.0" />
 	</ItemGroup>
 	<Import Project="..\VideoExport.Core\VideoExport.Core.projitems" Label="Shared" />

--- a/VideoExport.KKS/VideoExport.KKS.csproj
+++ b/VideoExport.KKS/VideoExport.KKS.csproj
@@ -5,7 +5,7 @@
 		<AssemblyName>VideoExport</AssemblyName>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="ScreenshotManager.KoikatsuSunshine" Version="21.0.0" />
+		<PackageReference Include="ScreenshotManager.KoikatsuSunshine" Version="21.1.2" />
 		<PackageReference Include="IllusionModdingAPI.KKSAPI" Version="1.43.0" />
 	</ItemGroup>
 	<Import Project="..\VideoExport.Core\VideoExport.Core.projitems" Label="Shared" />


### PR DESCRIPTION
  Match currentSize to SM's 1:1 180 output (was predicting 2:1), bump SM to 21.1.2.

<!--- If your change only affects some games or only one plugin out of multiple, 
      put this information in the title, e.g. "[ME][KK/KKS] Add a kitchen sink"-->

## Description
Fixes wrong size if 180° capture is selected. 

## Motivation and Context
Issue #208 

## How Has This Been Tested?
Exports in normal, 360 and 180 mode.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
