### PR TITLE
[Timeline] Fix #205 keyframe move crash

### DIFF
--- a/Timeline.Core/Timeline.cs
+++ b/Timeline.Core/Timeline.cs
@@ -2700,8 +2700,14 @@ namespace Timeline
                                         float referenceOldTime = reference.parent.keyframes.Keys[reference.parent.keyframes.IndexOfValue(reference)];
                                         bool forward = ordered[0].Value >= referenceOldTime;
                                         ordered.Sort((a, b) => forward ? b.Value.CompareTo(a.Value) : a.Value.CompareTo(b.Value));
+
                                         foreach (KeyValuePair<Keyframe, float> move in ordered)
-                                            TryMoveKeyframe(move.Key, move.Value); // precheck above guarantees success
+                                        {
+                                            if (!TryMoveKeyframe(move.Key, move.Value))
+                                            {
+                                                Logger.LogError("Move to " + move.Value + " failed despite passing the collision precheck");
+                                            }
+                                        }
                                     }
 
                                     e.Reset();
@@ -2824,7 +2830,11 @@ namespace Timeline
             {
                 KeyValuePair<float, Keyframe> pair = _selectedKeyframes[i];
                 float newTime = (float)(((pair.Key - min) * newSize) / currentSize + min);
-                TryMoveKeyframe(pair.Value, newTime);
+
+                if (!TryMoveKeyframe(pair.Value, newTime))
+                {
+                    Logger.LogError("Scale to " + newTime + " failed despite passing the collision precheck");
+                }
             }
             UpdateKeyframeWindow(false);
             UpdateGrid();

--- a/Timeline.Core/Timeline.cs
+++ b/Timeline.Core/Timeline.cs
@@ -2673,20 +2673,41 @@ namespace Timeline
                                 {
                                     if (_selectedKeyframesXOffset.Count == 0)
                                         return;
+
+                                    Dictionary<Keyframe, float> moves = new Dictionary<Keyframe, float>();
                                     foreach (KeyValuePair<KeyframeDisplay, float> pair in _selectedKeyframesXOffset)
                                     {
                                         RectTransform rt = ((RectTransform)pair.Key.gameObject.transform);
-                                        float time = 10f * rt.anchoredPosition.x / (_baseGridWidth * _zoomLevel);
-                                        MoveKeyframe(pair.Key.keyframe, time);
+                                        moves[pair.Key.keyframe] = 10f * rt.anchoredPosition.x / (_baseGridWidth * _zoomLevel);
+                                    }
 
-                                        int index = _selectedKeyframes.FindIndex(k => k.Value == pair.Key.keyframe);
-                                        if (index != -1)
-                                            _selectedKeyframes[index] = new KeyValuePair<float, Keyframe>(time, pair.Key.keyframe);
+                                    int blocked = 0;
+                                    foreach (KeyValuePair<Keyframe, float> move in moves)
+                                    {
+                                        Keyframe occupant = FindOccupant(move.Key.parent, move.Value, move.Key);
+                                        if (occupant != null && !moves.ContainsKey(occupant))
+                                            ++blocked;
+                                    }
+
+                                    if (blocked > 0)
+                                    {
+                                        Logger.LogMessage("Move blocked: " + blocked + " keyframe(s) would overlap existing keyframes");
+                                    }
+                                    else
+                                    {
+                                        List<KeyValuePair<Keyframe, float>> ordered = new List<KeyValuePair<Keyframe, float>>(moves);
+                                        Keyframe reference = ordered[0].Key;
+                                        float referenceOldTime = reference.parent.keyframes.Keys[reference.parent.keyframes.IndexOfValue(reference)];
+                                        bool forward = ordered[0].Value >= referenceOldTime;
+                                        ordered.Sort((a, b) => forward ? b.Value.CompareTo(a.Value) : a.Value.CompareTo(b.Value));
+                                        foreach (KeyValuePair<Keyframe, float> move in ordered)
+                                            TryMoveKeyframe(move.Key, move.Value); // precheck above guarantees success
                                     }
 
                                     e.Reset();
-                                    UpdateKeyframeWindow(false);
                                     _selectedKeyframesXOffset.Clear();
+                                    UpdateGrid();
+                                    UpdateKeyframeWindow(false);
                                 };
 
                                 _displayedKeyframes.Add(display);
@@ -2788,7 +2809,7 @@ namespace Timeline
                 foreach (KeyValuePair<float, Keyframe> pair in _selectedKeyframes)
                 {
                     float newTime = (float)(((pair.Key - min) * newSize) / currentSize + min);
-                    if (pair.Value.parent.keyframes.TryGetValue(newTime, out Keyframe otherKeyframe) && otherKeyframe != pair.Value)
+                    if (FindOccupant(pair.Value.parent, newTime, pair.Value) != null)
                     {
                         conflicting = true;
                         ++multiplier;
@@ -2803,8 +2824,7 @@ namespace Timeline
             {
                 KeyValuePair<float, Keyframe> pair = _selectedKeyframes[i];
                 float newTime = (float)(((pair.Key - min) * newSize) / currentSize + min);
-                MoveKeyframe(pair.Value, newTime);
-                _selectedKeyframes[i] = new KeyValuePair<float, Keyframe>(newTime, pair.Value);
+                TryMoveKeyframe(pair.Value, newTime);
             }
             UpdateKeyframeWindow(false);
             UpdateGrid();
@@ -2878,6 +2898,11 @@ namespace Timeline
 
         private void AddKeyframe(Interpolable interpolable, float time)
         {
+            if (FindOccupant(interpolable, time, null) != null)
+            {
+                Logger.LogMessage("A keyframe already exists at " + time);
+                return;
+            }
             try
             {
                 Keyframe keyframe;
@@ -2929,8 +2954,8 @@ namespace Timeline
                 {
                     foreach (KeyValuePair<float, Keyframe> pair in @group.Key.keyframes.Reverse())
                     {
-                        if (pair.Key >= time)
-                            MoveKeyframe(pair.Value, (float)(pair.Key + duration));
+                        if (pair.Key >= time && !TryMoveKeyframe(pair.Value, (float)(pair.Key + duration)))
+                            Logger.LogMessage("Couldn't make room at " + pair.Key + ": another keyframe already exists at " + (pair.Key + duration));
                     }
                 }
             }
@@ -2948,14 +2973,37 @@ namespace Timeline
             UpdateGrid();
         }
 
-        private void MoveKeyframe(Keyframe keyframe, float destinationTime)
+        // Destination times come from pixel round-trips, so a keyframe aimed exactly at another's
+        // time can land ~2e-7 off. An exact SortedList lookup misses that and lets a near-duplicate
+        // through, which is the collision this is meant to catch.
+        private static Keyframe FindOccupant(Interpolable interpolable, float time, Keyframe self)
         {
-            Logger.LogError(keyframe.parent.keyframes.IndexOfValue(keyframe));
-            keyframe.parent.keyframes.RemoveAt(keyframe.parent.keyframes.IndexOfValue(keyframe));
-            keyframe.parent.keyframes.Add(destinationTime, keyframe);
+            SortedList<float, Keyframe> keyframes = interpolable.keyframes;
+            for (int i = 0; i < keyframes.Count; i++)
+            {
+                if (!Mathf.Approximately(keyframes.Keys[i], time))
+                    continue;
+                Keyframe candidate = keyframes.Values[i];
+                if (candidate != self)
+                    return candidate;
+            }
+            return null;
+        }
+
+        private bool TryMoveKeyframe(Keyframe keyframe, float destinationTime)
+        {
+            SortedList<float, Keyframe> keyframes = keyframe.parent.keyframes;
+            if (FindOccupant(keyframe.parent, destinationTime, keyframe) != null)
+                return false; // slot held by another keyframe: don't remove, don't orphan
+            int index = keyframes.IndexOfValue(keyframe);
+            if (index < 0)
+                return false;
+            keyframes.RemoveAt(index);
+            keyframes.Add(destinationTime, keyframe);
             int i = _selectedKeyframes.FindIndex(k => k.Value == keyframe);
             if (i != -1)
                 _selectedKeyframes[i] = new KeyValuePair<float, Keyframe>(destinationTime, keyframe);
+            return true;
         }
 
         private void OnGridTopMouse(PointerEventData eventData)
@@ -3618,42 +3666,48 @@ namespace Timeline
 
         private void DeleteKeyframes(IEnumerable<KeyValuePair<float, Keyframe>> keyframes, bool removeInterpolables = true)
         {
-            float min = float.PositiveInfinity;
-            float max = float.NegativeInfinity;
             keyframes = keyframes.ToList();
+            Dictionary<Interpolable, float> deletedMin = new Dictionary<Interpolable, float>();
+            Dictionary<Interpolable, float> deletedMax = new Dictionary<Interpolable, float>();
             foreach (KeyValuePair<float, Keyframe> pair in keyframes)
             {
                 if (pair.Value == null) //Just a safeguard.
                     continue;
-                if (pair.Key < min)
-                    min = pair.Key;
-                if (pair.Key > max)
-                    max = pair.Key;
+                Interpolable parent = pair.Value.parent;
+                if (!deletedMin.TryGetValue(parent, out float pMin) || pair.Key < pMin)
+                    deletedMin[parent] = pair.Key;
+                if (!deletedMax.TryGetValue(parent, out float pMax) || pair.Key > pMax)
+                    deletedMax[parent] = pair.Key;
                 try
                 {
-                    pair.Value.parent.keyframes.Remove(pair.Key);
-                    if (removeInterpolables && pair.Value.parent.keyframes.Count == 0)
-                        RemoveInterpolable(pair.Value.parent);
+                    parent.keyframes.Remove(pair.Key);
+                    if (removeInterpolables && parent.keyframes.Count == 0)
+                        RemoveInterpolable(parent);
                 }
                 catch (Exception e)
                 {
-                    Logger.LogError("Couldn't delete keyframe with time \"" + pair.Key + "\" and value \"" + pair.Value + "\" from interpolable \"" + pair.Value.parent + "\"\n" + e);
+                    Logger.LogError("Couldn't delete keyframe with time \"" + pair.Key + "\" and value \"" + pair.Value + "\" from interpolable \"" + parent + "\"\n" + e);
                 }
             }
 
             if (Input.GetKey(KeyCode.LeftAlt))
             {
-                double duration = max - min + (_blockLength / _divisions);
-                //IDK, grouping didn't work so I'm doing it like this
-                HashSet<Interpolable> processedParents = new HashSet<Interpolable>();
-                foreach (KeyValuePair<float, Keyframe> k in keyframes)
+                float step = _blockLength / _divisions;
+                foreach (Interpolable parent in deletedMin.Keys)
                 {
-                    if (processedParents.Contains(k.Value.parent) != false)
-                        continue;
-                    processedParents.Add(k.Value.parent);
-                    foreach (KeyValuePair<float, Keyframe> pair in k.Value.parent.keyframes.ToList())
-                        if (pair.Key > min)
-                            MoveKeyframe(pair.Value, (float)(pair.Key - duration));
+                    float parentMin = deletedMin[parent];
+                    // Spans a non-contiguous selection as one block, so the shift can overshoot past zero.
+                    double duration = deletedMax[parent] - parentMin + step;
+                    foreach (KeyValuePair<float, Keyframe> pair in parent.keyframes.ToList())
+                    {
+                        if (pair.Key <= parentMin)
+                            continue;
+                        float newTime = (float)(pair.Key - duration);
+                        if (newTime < 0f)
+                            Logger.LogMessage("Couldn't close gap at " + pair.Key + ": " + newTime + " is before the start of the timeline");
+                        else if (!TryMoveKeyframe(pair.Value, newTime))
+                            Logger.LogMessage("Couldn't close gap at " + pair.Key + ": another keyframe already exists at " + newTime);
+                    }
                 }
             }
             _selectedKeyframes.RemoveAll(elem => elem.Value == null || keyframes.Any(k => k.Value == elem.Value));


### PR DESCRIPTION
## Description
  Dropping a keyframe on a time that was already taken lost it. It got pulled out of the track before anything checked the new spot was free, and then putting it back failed. The keyframe still showed on screen but was gone from the track, and Timeline stopped responding until Studio was restarted.

  Now the spot is checked before anything moves. If it's taken, nothing moves and a message says why. Keyframes moving together are moved in an order that lets them pass through each other's old positions.
  
  Also fixed: adding a keyframe on top of another dumped an exception in the log, gap closing could try to move keyframes before the start of the timeline, and Alt paste stayed quiet when it couldn't make room.
  
  ## Motivation and Context
  Issue #205

  ## How Has This Been Tested?
  In Studio on HS2 and KK

  - The repro from the issue: two keyframes selected, Alt+drag forward with Shift so the left one lands on the right one's old spot
  - Same drag backwards
  - Dragging onto a keyframe that isn't selected, which should move nothing at all
  - Dropping a keyframe back where it started
  - Dragging a selection spanning two tracks
  - Scaling a selection spanning two tracks, including tracks with keyframes at the same time
  - Cut and paste with Alt
  - Gap closing on one track
  - Gap closing on two tracks with different sized gaps
  - Gap closing with a keyframe left in between, which correctly refuses to move it before the start of the timeline

  ## Screenshots (if appropriate):

  ## Types of changes
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
