### PR TITLE
[VE] Fix #200 first exported frame captured mid-frame

### DIFF
--- a/VideoExport.Core/VideoExport.cs
+++ b/VideoExport.Core/VideoExport.cs
@@ -1148,22 +1148,16 @@ namespace VideoExport
                 _recordingFrameLimit = -1;
             }
 
-            if (_selectedLimitDuration == LimitDurationType.Timeline)
+            if (_selectedLimitDuration == LimitDurationType.Timeline && _realignTimeline)
             {
-                if (_realignTimeline)
-                {
-                    TimelineCompatibility.Stop();
-                    TimelineCompatibility.Play();
+                TimelineCompatibility.Stop();
+                TimelineCompatibility.Play();
+                yield return new WaitForEndOfFrame();
+                TimelineCompatibility.Stop();
+
+                // Wait for dynamic bones and other physics to settle
+                for (int x = 0; x < _fps; x++)
                     yield return new WaitForEndOfFrame();
-                    TimelineCompatibility.Stop();
-
-                    // Wait for dynamic bones and other physics to settle
-                    for (int x = 0; x < _fps; x++)
-                        yield return new WaitForEndOfFrame();
-                }
-
-                if (TimelineCompatibility.GetIsPlaying() == false)
-                    TimelineCompatibility.Play();
             }
 
             ParallelScreenshotEncoder parallelEncoder = null;
@@ -1319,6 +1313,12 @@ namespace VideoExport
                     }
                 )
             );
+
+            yield return new WaitForEndOfFrame();
+
+            // Must start after the wait above, otherwise the timeline runs a frame ahead of the first capture.
+            if (_selectedLimitDuration == LimitDurationType.Timeline && TimelineCompatibility.GetIsPlaying() == false)
+                TimelineCompatibility.Play();
 
             int generatedFrames = 0;
             for (; ; i++)


### PR DESCRIPTION
## Description
  The first frame was captured mid-frame instead of at end of frame. Capture forces a re-render, and at that point FinalIK has reset the skeleton via `SolverManager.Update` -> `FixTransforms` and only solves in `LateUpdate`, so IK characters rendered out of pose (FK is applied in `LateUpdate` and not reset, so FK-only was fine). Now waits for end of frame once before the capture loop. Since that costs a frame on paths already at end of frame, `TimelineCompatibility.Play()` moved to after the wait.

  ## Motivation and Context
  Fixes #200. Reported on HS2, reproduced on KKS.

  ## How Has This Been Tested?
  A/B in KKS CharaStudio, same scene and settings (Generate Video on, limit by frames, IK enabled):
  `main` reproduces it, this branch does not. Timeline-limited exports still start at the first timeline frame.

  ## Screenshots (if appropriate):
  <!-- before/after first frame -->

  ## Types of changes
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
