### PR TITLE
[Timeline] Fix #212 by re-applying animation state on scene load

### DIFF
--- a/Timeline.Core/Timeline.cs
+++ b/Timeline.Core/Timeline.cs
@@ -4073,6 +4073,14 @@ namespace Timeline
             {
                 Stop();
             }
+            else
+            {
+                // A scene card restores the pose of whatever frame it was saved at, and interpolation is
+                // skipped while paused, so without this the scene sits on one frame and the cursor on another.
+                UpdateCursor();
+                Interpolate(true);
+                Interpolate(false);
+            }
         }
 
         private void LoadSingle(string path)


### PR DESCRIPTION
## Description
  `SceneLoad` only re-applied animation state when `Autoplay` was `Yes` or `No`. The default is `Ignore`, which did neither, and `InterpolateBefore`/`InterpolateAfter` early-return while paused. So after a load the cursor and the scene sat on different frames. Added the missing branch: re-apply at the current playback time without touching play state.

  ## Motivation and Context
  Fixes #212. Auto Keyframe's "Auto current value" rewrites the keyframe under the cursor from live scene state, so the desync silently destroyed the keyframe at 0:00. The desync itself is reproducible with Auto Keyframe uninstalled.

  ## How Has This Been Tested?
  KK, Timeline 1.5.5.1 + Auto Keyframe 1.3.0.0. 
  Against main, confirming the bug:
  - Cursor/scene desync after load, with Auto Keyframe uninstalled
  - Keyframe at 0:00 overwritten with the card's pose
  - Overwrite follows the cursor, not keyframe 0, parked at 0:05, that keyframe was hit instead
  - Nothing overwritten with the cursor parked between keyframes, despite the desync
  - No overwrite for a card saved at 0:00
  - No overwrite when loaded during playback
  - No overwrite with `Autoplay = No`

  Against the fix:
  - Scene matches the cursor immediately on load, no desync
  - No keyframe modified in any of the repro cases


  ## Types of changes
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)